### PR TITLE
A bunch of changes

### DIFF
--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import collections
-import itertools
 from math import isnan
 
 import numpy
@@ -17,24 +15,7 @@ class Bunch(object):
     pass
 
 
-class OrderedCounter(collections.Counter, collections.OrderedDict):
-    """A Counter object that has deterministic iteration order."""
-    pass
-
-
-def generate(indexed_ops, temporaries, shape_map, apply_ordering):
-    temporaries_set = set(temporaries)
-    ops = [op for indices, op in indexed_ops]
-
-    code = make_loop_tree(indexed_ops)
-
-    reference_count = collections.Counter()
-    for op in ops:
-        reference_count.update(count_references(temporaries_set, op))
-    assert temporaries_set == set(reference_count)
-
-    indices, declare = place_declarations(code, reference_count, shape_map, apply_ordering, ops)
-
+def generate(temporaries, code, indices, declare):
     parameters = Bunch()
     parameters.declare = declare
     parameters.indices = indices
@@ -44,92 +25,6 @@ def generate(indexed_ops, temporaries, shape_map, apply_ordering):
         parameters.names[temp] = "t%d" % i
 
     return arabica(code, parameters)
-
-
-def make_loop_tree(indexed_ops, level=0):
-    keyfunc = lambda (indices, op): indices[level:level+1]
-    statements = []
-    for first_index, op_group in itertools.groupby(indexed_ops, keyfunc):
-        if first_index:
-            inner_block = make_loop_tree(op_group, level+1)
-            statements.append(imp.For(first_index[0], inner_block))
-        else:
-            statements.extend(op for indices, op in op_group)
-    return imp.Block(statements)
-
-
-def count_references(temporaries, op):
-    counter = collections.Counter()
-
-    def recurse(o, top=False):
-        if o in temporaries:
-            counter[o] += 1
-
-        if top or o not in temporaries:
-            if isinstance(o, (ein.Literal, ein.Variable)):
-                pass
-            elif isinstance(o, ein.Indexed):
-                recurse(o.children[0])
-            else:
-                for c in o.children:
-                    recurse(c)
-
-    if isinstance(op, imp.Evaluate):
-        recurse(op.expression, top=True)
-    elif isinstance(op, imp.Initialise):
-        counter[op.indexsum] += 1
-    elif isinstance(op, imp.Return):
-        recurse(op.expression)
-    elif isinstance(op, imp.Accumulate):
-        counter[op.indexsum] += 1
-        recurse(op.indexsum.children[0])
-    else:
-        raise AssertionError("unhandled operation: %s" % type(op))
-
-    return counter
-
-
-def place_declarations(tree, reference_count, shape_map, apply_ordering, operations):
-    temporaries = set(reference_count)
-    indices = {}
-    # We later iterate over declare keys, so need this to be ordered
-    declare = collections.OrderedDict()
-
-    def recurse(expr, loop_indices):
-        if isinstance(expr, imp.Block):
-            declare[expr] = []
-            # Need to iterate over counter in given order
-            counter = OrderedCounter()
-            for statement in expr.children:
-                counter.update(recurse(statement, loop_indices))
-            for e, count in counter.items():
-                if count == reference_count[e]:
-                    indices[e] = apply_ordering(set(shape_map(e)) - loop_indices)
-                    if indices[e]:
-                        declare[expr].append(e)
-                    del counter[e]
-            return counter
-        elif isinstance(expr, imp.For):
-            return recurse(expr.children[0], loop_indices | {expr.index})
-        else:
-            return count_references(temporaries, expr)
-
-    remainder = recurse(tree, set())
-    assert not remainder
-
-    for op in operations:
-        declare[op] = False
-        if isinstance(op, imp.Evaluate):
-            e = op.expression
-        elif isinstance(op, imp.Initialise):
-            e = op.indexsum
-        else:
-            continue
-
-        if len(indices[e]) == 0:
-            declare[op] = True
-
-    return indices, declare
 
 
 def _coffee_symbol(symbol, rank=()):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -162,9 +162,7 @@ def compile_integral(integral, idata, fd, prefix, parameters):
         fem.process(integral_type, integrand, tabulation_manager, quad_rule.weights, argument_indices, coefficient_map)
     nonfem = [ein.IndexSum(e, quadrature_index) for e in nonfem]
     simplified = opt.remove_componenttensors(nonfem)
-
     simplified = opt.unroll_indexsum(simplified, max_extent=3)
-    simplified = opt.remove_componenttensors(simplified)
 
     refcount = sch.count_references(simplified)
     candidates = set()

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -161,12 +161,10 @@ def compile_integral(integral, idata, fd, prefix, parameters):
     quadrature_index, nonfem, cell_orientations = \
         fem.process(integral_type, integrand, tabulation_manager, quad_rule.weights, argument_indices, coefficient_map)
     nonfem = [ein.IndexSum(e, quadrature_index) for e in nonfem]
-    inlining_cache = {}
-    simplified = [opt.inline_indices(e, inlining_cache) for e in nonfem]
+    simplified = opt.remove_componenttensors(nonfem)
 
-    simplified = opt.expand_indexsum(simplified, max_extent=3)
-    inlining_cache = {}
-    simplified = [opt.inline_indices(e, inlining_cache) for e in simplified]
+    simplified = opt.unroll_indexsum(simplified, max_extent=3)
+    simplified = opt.remove_componenttensors(simplified)
 
     refcount = sch.count_references(simplified)
     candidates = set()

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -12,7 +12,7 @@ from tsfc.quadrature import create_quadrature, QuadratureRule
 
 import coffee.base as coffee
 
-from tsfc import fem, gem as ein, impero as imp, scheduling as sch, optimise as opt
+from tsfc import fem, gem as ein, impero as imp, scheduling as sch, optimise as opt, impero_utils
 from tsfc.coffee import SCALAR_TYPE, generate as generate_coffee
 from tsfc.constants import default_parameters
 from tsfc.node import traversal
@@ -208,7 +208,11 @@ def compile_integral(integral, idata, fd, prefix, parameters):
         return None
     temporaries = make_temporaries(op for loop_indices, op in indexed_ops)
 
-    body = generate_coffee(indexed_ops, temporaries, shape_map, apply_ordering)
+    tree, indices, declare = impero_utils.process(indexed_ops,
+                                                  temporaries,
+                                                  shape_map,
+                                                  apply_ordering)
+    body = generate_coffee(temporaries, tree, indices, declare)
     body.open_scope = False
 
     funname = "%s_%s_integral_%s" % (prefix, integral_type, integral.subdomain_id())

--- a/tsfc/gem.py
+++ b/tsfc/gem.py
@@ -324,6 +324,12 @@ class Index(object):
         elif self.extent != value:
             raise ValueError("Inconsistent index extents!")
 
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return "Index(%r)" % self.name
+
 
 class VariableIndex(object):
     def __init__(self, name):

--- a/tsfc/gem.py
+++ b/tsfc/gem.py
@@ -350,15 +350,22 @@ class Indexed(Scalar):
         # Zero folding
         if isinstance(aggregate, Zero):
             return Zero()
-        else:
-            return super(Indexed, cls).__new__(cls)
 
-    def __init__(self, aggregate, multiindex):
+        # All indices fixed
+        if all(isinstance(i, int) for i in multiindex):
+            if isinstance(aggregate, Literal):
+                return Literal(aggregate.array[multiindex])
+            elif isinstance(aggregate, ListTensor):
+                return aggregate.array[multiindex]
+
+        self = super(Indexed, cls).__new__(cls)
         self.children = (aggregate,)
         self.multiindex = multiindex
 
         new_indices = tuple(i for i in multiindex if isinstance(i, Index))
         self.free_indices = tuple(unique(aggregate.free_indices + new_indices))
+
+        return self
 
 
 class ComponentTensor(Node):

--- a/tsfc/impero.py
+++ b/tsfc/impero.py
@@ -1,19 +1,37 @@
+"""Impero is a helper AST for generating C code (or equivalent,
+e.g. COFFEE) from GEM.  An Impero expression is a proper tree, not
+directed acyclic graph (DAG).  Impero is a helper AST, not a
+standalone language; it is incomplete without GEM as its terminals
+refer to nodes from GEM expressions.
+
+Trivia:
+ - Impero helps translating GEM into an imperative language.
+ - Byzantine units in Age of Empires II sometimes say 'Impero?'
+   (Command?) after clicking on them.
+"""
+
 from __future__ import absolute_import
 
-from tsfc.node import Node as node_Node
+from tsfc.node import Node as NodeBase
 
 
-class Node(node_Node):
+class Node(NodeBase):
+    """Base class of all Impero nodes"""
+
     __slots__ = ()
 
 
 class Terminal(Node):
+    """Abstract class for terminal Impero nodes"""
+
     __slots__ = ()
 
     children = ()
 
 
 class Evaluate(Terminal):
+    """Assign the value of a GEM expression to a temporary."""
+
     __slots__ = ('expression',)
     __front__ = ('expression',)
 
@@ -22,6 +40,8 @@ class Evaluate(Terminal):
 
 
 class Initialise(Terminal):
+    """Initialise an :class:`gem.IndexSum`."""
+
     __slots__ = ('indexsum',)
     __front__ = ('indexsum',)
 
@@ -30,6 +50,8 @@ class Initialise(Terminal):
 
 
 class Accumulate(Terminal):
+    """Accumulate terms into an :class:`gem.IndexSum`."""
+
     __slots__ = ('indexsum',)
     __front__ = ('indexsum',)
 
@@ -38,6 +60,9 @@ class Accumulate(Terminal):
 
 
 class Return(Terminal):
+    """Save value of GEM expression into an lvalue. Used to "return"
+    values from a kernel."""
+
     __slots__ = ('variable', 'expression')
     __front__ = ('variable', 'expression')
 
@@ -47,6 +72,9 @@ class Return(Terminal):
 
 
 class Block(Node):
+    """An ordered set of Impero expressions.  Corresponds to a curly
+    braces block in C."""
+
     __slots__ = ('children',)
 
     def __init__(self, statements):
@@ -54,6 +82,9 @@ class Block(Node):
 
 
 class For(Node):
+    """For loop with an index which stores its extent, and a loop body
+    expression which is usually a :class:`Block`."""
+
     __slots__ = ('index', 'children')
     __front__ = ('index',)
 

--- a/tsfc/impero_utils.py
+++ b/tsfc/impero_utils.py
@@ -1,0 +1,121 @@
+from __future__ import absolute_import
+
+import collections
+import itertools
+
+from tsfc import gem, impero as imp
+
+
+class OrderedCounter(collections.Counter, collections.OrderedDict):
+    """A Counter object that has deterministic iteration order."""
+    pass
+
+
+def process(indexed_ops, temporaries, shape_map, apply_ordering):
+    temporaries_set = set(temporaries)
+    ops = [op for indices, op in indexed_ops]
+
+    code = make_loop_tree(indexed_ops)
+
+    reference_count = collections.Counter()
+    for op in ops:
+        reference_count.update(count_references(temporaries_set, op))
+    assert temporaries_set == set(reference_count)
+
+    indices, declare = place_declarations(code, reference_count, shape_map, apply_ordering, ops)
+
+    return code, indices, declare
+
+
+def make_loop_tree(indexed_ops, level=0):
+    """Creates an Impero AST with loops from a list of operations and
+    their respective free indices.
+
+    :arg indexed_ops: A list of (free indices, operation) pairs, each
+                      operation must be an Impero terminal node.
+    :arg level: depth of loop nesting
+    :returns: Impero AST with loops, without declarations
+    """
+    keyfunc = lambda (indices, op): indices[level:level+1]
+    statements = []
+    for first_index, op_group in itertools.groupby(indexed_ops, keyfunc):
+        if first_index:
+            inner_block = make_loop_tree(op_group, level+1)
+            statements.append(imp.For(first_index[0], inner_block))
+        else:
+            statements.extend(op for indices, op in op_group)
+    return imp.Block(statements)
+
+
+def count_references(temporaries, op):
+    counter = collections.Counter()
+
+    def recurse(o, top=False):
+        if o in temporaries:
+            counter[o] += 1
+
+        if top or o not in temporaries:
+            if isinstance(o, (gem.Literal, gem.Variable)):
+                pass
+            elif isinstance(o, gem.Indexed):
+                recurse(o.children[0])
+            else:
+                for c in o.children:
+                    recurse(c)
+
+    if isinstance(op, imp.Evaluate):
+        recurse(op.expression, top=True)
+    elif isinstance(op, imp.Initialise):
+        counter[op.indexsum] += 1
+    elif isinstance(op, imp.Return):
+        recurse(op.expression)
+    elif isinstance(op, imp.Accumulate):
+        counter[op.indexsum] += 1
+        recurse(op.indexsum.children[0])
+    else:
+        raise AssertionError("unhandled operation: %s" % type(op))
+
+    return counter
+
+
+def place_declarations(tree, reference_count, shape_map, apply_ordering, operations):
+    temporaries = set(reference_count)
+    indices = {}
+    # We later iterate over declare keys, so need this to be ordered
+    declare = collections.OrderedDict()
+
+    def recurse(expr, loop_indices):
+        if isinstance(expr, imp.Block):
+            declare[expr] = []
+            # Need to iterate over counter in given order
+            counter = OrderedCounter()
+            for statement in expr.children:
+                counter.update(recurse(statement, loop_indices))
+            for e, count in counter.items():
+                if count == reference_count[e]:
+                    indices[e] = apply_ordering(set(shape_map(e)) - loop_indices)
+                    if indices[e]:
+                        declare[expr].append(e)
+                    del counter[e]
+            return counter
+        elif isinstance(expr, imp.For):
+            return recurse(expr.children[0], loop_indices | {expr.index})
+        else:
+            return count_references(temporaries, expr)
+
+    remainder = recurse(tree, set())
+    assert not remainder
+
+    for op in operations:
+        declare[op] = False
+        if isinstance(op, imp.Evaluate):
+            e = op.expression
+        elif isinstance(op, imp.Initialise):
+            e = op.indexsum
+        else:
+            continue
+
+        if len(indices[e]) == 0:
+            declare[op] = True
+
+    return indices, declare

--- a/tsfc/optimise.py
+++ b/tsfc/optimise.py
@@ -2,60 +2,24 @@ from __future__ import absolute_import
 
 from singledispatch import singledispatch
 
+from tsfc.node import Memoizer, MemoizerArg, reuse_if_untouched, reuse_if_untouched_arg
 from tsfc.gem import Node, Zero, Sum, Indexed, IndexSum, ComponentTensor
-
-
-class Memoizer(object):
-    def __init__(self, function):
-        self.cache = {}
-        self.function = function
-
-    def __call__(self, node):
-        try:
-            return self.cache[node]
-        except KeyError:
-            result = self.function(node, self)
-            self.cache[node] = result
-            return result
-
-
-class MemoizerWithArg(object):
-    def __init__(self, function):
-        self.cache = {}
-        self.function = function
-
-    def __call__(self, node, arg):
-        cache_key = (node, arg)
-        try:
-            return self.cache[cache_key]
-        except KeyError:
-            result = self.function(node, self, arg)
-            self.cache[cache_key] = result
-            return result
-
-
-def reuse_if_untouched(node, self):
-    new_children = map(self, node.children)
-    if all(nc == c for nc, c in zip(new_children, node.children)):
-        return node
-    else:
-        return node.reconstruct(*new_children)
-
-
-def reuse_if_untouched_with_arg(node, self, arg):
-    new_children = [self(child, arg) for child in node.children]
-    if all(nc == c for nc, c in zip(new_children, node.children)):
-        return node
-    else:
-        return node.reconstruct(*new_children)
 
 
 @singledispatch
 def replace_indices(node, self, subst):
+    """Replace free indices in a GEM expression.
+
+    :arg node: root of the expression
+    :arg self: function for recursive calls
+    :arg subst: tuple of pairs; each pair is a substitution
+                rule with a free index to replace and an index to
+                replace with.
+    """
     raise AssertionError("cannot handle type %s" % type(node))
 
 
-replace_indices.register(Node)(reuse_if_untouched_with_arg)
+replace_indices.register(Node)(reuse_if_untouched_arg)
 
 
 @replace_indices.register(Indexed)  # noqa
@@ -64,9 +28,12 @@ def _(node, self, subst):
     substitute = dict(subst)
     multiindex = tuple(substitute.get(i, i) for i in node.multiindex)
     if isinstance(child, ComponentTensor):
+        # Indexing into ComponentTensor
+        # Inline ComponentTensor and augment the substitution rules
         substitute.update(zip(child.multiindex, multiindex))
         return self(child.children[0], tuple(sorted(substitute.items())))
     else:
+        # Replace indices
         new_child = self(child, subst)
         if new_child == child and multiindex == node.multiindex:
             return node
@@ -75,24 +42,36 @@ def _(node, self, subst):
 
 
 def filtered_replace_indices(node, self, subst):
+    """Wrapper for :func:`replace_indices`.  At each call removes
+    substitution rules that do not apply."""
     filtered_subst = tuple((k, v) for k, v in subst if k in node.free_indices)
     return replace_indices(node, self, filtered_subst)
 
 
-def replace_indices_top(node, self, subst):
-    if subst:
-        return filtered_replace_indices(node, self, subst)
+def filtered_replace_indices_top(node, self, subst):
+    """Wrapper for :func:`replace_indices`.  At each call removes
+    substitution rules that do not apply.  Stops recursion when there
+    is nothing to substitute."""
+    filtered_subst = tuple((k, v) for k, v in subst if k in node.free_indices)
+    if filtered_subst:
+        return replace_indices(node, self, filtered_subst)
     else:
         return node
 
 
 def remove_componenttensors(expressions):
-    mapper = MemoizerWithArg(filtered_replace_indices)
+    """Removes all ComponentTensors from a list of expression DAGs."""
+    mapper = MemoizerArg(filtered_replace_indices)
     return [mapper(expression, ()) for expression in expressions]
 
 
 @singledispatch
 def _unroll_indexsum(node, self):
+    """Unrolls IndexSums below a certain extent.
+
+    :arg node: root of the expression
+    :arg self: function for recursive calls
+    """
     raise AssertionError("cannot handle type %s" % type(node))
 
 
@@ -102,6 +81,7 @@ _unroll_indexsum.register(Node)(reuse_if_untouched)
 @_unroll_indexsum.register(IndexSum)  # noqa
 def _(node, self):
     if node.index.extent <= self.max_extent:
+        # Unrolling
         summand = self(node.children[0])
         return reduce(Sum,
                       (self.replace(summand, ((node.index, i),))
@@ -112,7 +92,13 @@ def _(node, self):
 
 
 def unroll_indexsum(expressions, max_extent):
+    """Unrolls IndexSums below a specified extent.
+
+    :arg expressions: list of expression DAGs
+    :arg max_extent: maximum extent for which IndexSums are unrolled
+    :returns: list of expression DAGs with some unrolled IndexSums
+    """
     mapper = Memoizer(_unroll_indexsum)
     mapper.max_extent = max_extent
-    mapper.replace = MemoizerWithArg(replace_indices_top)
+    mapper.replace = MemoizerArg(filtered_replace_indices_top)
     return map(mapper, expressions)


### PR DESCRIPTION
This pull request brings a bunch of changes which somewhat build upon each other:
 * Docstrings for impero.py
 * Pull COFFEE-independent code out of coffee.py into impero_utils.py
 * A sensible DAG-visiting infrastructure
 * Performance improvements for ComponentTensor inlining
 * Performance improvements for IndexSum expansion
 * Docstrings for the optimisation module and the newly added visitor tools

I would like to emphasise that these changes **improve compilation speed** significantly for complicated forms, especially with the default settings (IndexSum expansion for small loops).