### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,0 +1,2 @@
+numpy
+singledispatch

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,0 +1,3 @@
+git+https://github.com/coneoproject/COFFEE#egg=COFFEE
+git+https://bitbucket.org/mapdes/ufl.git#egg=ufl
+git+https://bitbucket.org/mapdes/fiat.git#egg=fiat

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-numpy
-singledispatch
-git+https://github.com/coneoproject/COFFEE#egg=COFFEE
-git+https://bitbucket.org/mapdes/ufl.git#egg=ufl
-git+https://bitbucket.org/mapdes/fiat.git#egg=fiat
+-r requirements-ext.txt
+-r requirements-git.txt


### PR DESCRIPTION
Without a `requirements-ext.txt` the install script installs everything from `requirements.txt`. That means the pip installation of COFFEE, FIAT and UFL, so we end up with two installations of these in the virtualenv.