### PR TITLE
Some clean up in fem.py

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
-import numpy
+import collections
 import time
+
+import numpy
 
 from ufl.algorithms import compute_form_data
 from ufl.log import GREEN
@@ -141,7 +143,7 @@ def compile_integral(idata, fd, prefix, parameters):
     # multiple times with the same table.  Occurs, for example, if we
     # have multiple integrals here (and the affine coordinate
     # evaluation can be hoisted).
-    index_cache = {}
+    index_cache = collections.defaultdict(ein.Index)
     for i, integral in enumerate(idata.integrals):
         params = {}
         # Record per-integral parameters
@@ -171,7 +173,8 @@ def compile_integral(idata, fd, prefix, parameters):
             fem.process(integral_type, integrand, tabulation_manager,
                         quad_rule.weights, quadrature_index,
                         argument_indices, coefficient_map, index_cache)
-        nonfem_.append([ein.IndexSum(e, quadrature_index) for e in nonfem])
+        nonfem_.append([(ein.IndexSum(e, quadrature_index) if quadrature_index in e.free_indices else e)
+                        for e in nonfem])
 
     # Sum the expressions that are part of the same restriction
     nonfem = list(reduce(ein.Sum, e, ein.Zero()) for e in zip(*nonfem_))

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -45,6 +45,7 @@ class ReplaceSpatialCoordinates(MultiFunction):
         return t
 
     def spatial_coordinate(self, o):
+        assert o.ufl_domain().ufl_coordinate_element().mapping() == "identity"
         return ReferenceValue(self.coordinates)
 
 

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -138,7 +138,7 @@ def translate(terminal, mt, params):
 
 @translate.register(CellOrientation)  # noqa
 def _(terminal, mt, params):
-    cell_orientations = params.get_cell_orientations()
+    cell_orientations = params.cell_orientations
     f = {None: 0, '+': 0, '-': 1}[mt.restriction]
     co_int = gem.Indexed(cell_orientations, (f, 0))
     return gem.Conditional(gem.Comparison("==", co_int, gem.Literal(1)),

--- a/tsfc/node.py
+++ b/tsfc/node.py
@@ -97,8 +97,15 @@ class Node(object):
 
 def traversal(expression_dags):
     """Pre-order traversal of the nodes of expression DAGs."""
-    seen = set(expression_dags)
-    lifo = list(expression_dags)
+    seen = set()
+    lifo = []
+    # Some roots might be same, but they must be visited only once.
+    # Keep the original ordering of roots, for deterministic code
+    # generation.
+    for root in expression_dags:
+        if root not in seen:
+            seen.add(root)
+            lifo.append(root)
 
     while lifo:
         node = lifo.pop()

--- a/tsfc/scheduling.py
+++ b/tsfc/scheduling.py
@@ -171,4 +171,5 @@ def make_ordering(assignments, indices_map):
 
     for o in queue:
         handle(o, enqueue, emit)
+    assert not any(queue.waiting.values())
     return list(reversed(result))


### PR DESCRIPTION
Mostly clean up and some new docstrings. Other changes:
 * Cellwise constant Arguments are now treated as cellwise constant.
 * Cellwise constant FormArguments are the same on all facets, thus they don't a facet number to look up the right tabulation matrix.
 * Cellwise constant Coefficient evaluation is expanded if the tabulation vector contains at most 2 nonzeros. This way the generated code for the evaluation of the Jacobian on P1 simplices is equivalent to the code snippets we earlier had.
 * Simplification of absolute values and cell orientations is rewritten, using the saner DAG visitor infrastructure from `tsfc.node`.  This also demonstrates the generality of the DAG visitor infrastructure, as it can handle both UFL and GEM.
 * No more `fabs(sqrt(...))`