### PR TITLE
Optimise generated code

### DIFF
--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -103,6 +103,12 @@ def _(leaf, parameters):
                        expression(leaf.expression, parameters))
 
 
+@arabica.register(imp.ReturnAccumulate)  # noqa: Not actually redefinition
+def _(leaf, parameters):
+    return coffee.Incr(expression(leaf.variable, parameters),
+                       expression(leaf.indexsum.children[0], parameters))
+
+
 @arabica.register(imp.Evaluate)  # noqa: Not actually redefinition
 def _(leaf, parameters):
     expr = leaf.expression

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -173,14 +173,13 @@ def compile_integral(idata, fd, prefix, parameters):
                              tabulation_manager, quad_rule.weights,
                              quadrature_index, argument_indices,
                              coefficient_map, index_cache)
+        nonfem = opt.unroll_indexsum(nonfem, max_extent=3)
         nonfem_.append([(ein.IndexSum(e, quadrature_index) if quadrature_index in e.free_indices else e)
                         for e in nonfem])
 
     # Sum the expressions that are part of the same restriction
     nonfem = list(reduce(ein.Sum, e, ein.Zero()) for e in zip(*nonfem_))
-
     simplified = opt.remove_componenttensors(nonfem)
-    simplified = opt.unroll_indexsum(simplified, max_extent=3)
 
     cell_orientations = False
     refcount = sch.count_references(simplified)

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -436,7 +436,7 @@ def make_temporaries(operations):
             list.append(o)
 
     for op in operations:
-        if isinstance(op, (imp.Initialise, imp.Return)):
+        if isinstance(op, (imp.Initialise, imp.Return, imp.ReturnAccumulate)):
             pass
         elif isinstance(op, imp.Accumulate):
             make_temporary(op.indexsum)

--- a/tsfc/impero.py
+++ b/tsfc/impero.py
@@ -71,6 +71,18 @@ class Return(Terminal):
         self.expression = expression
 
 
+class ReturnAccumulate(Terminal):
+    """Accumulate an :class:`gem.IndexSum` directly into a return
+    variable."""
+
+    __slots__ = ('variable', 'indexsum')
+    __front__ = ('variable', 'indexsum')
+
+    def __init__(self, variable, indexsum):
+        self.variable = variable
+        self.indexsum = indexsum
+
+
 class Block(Node):
     """An ordered set of Impero expressions.  Corresponds to a curly
     braces block in C."""

--- a/tsfc/impero_utils.py
+++ b/tsfc/impero_utils.py
@@ -72,6 +72,8 @@ def count_references(temporaries, op):
     elif isinstance(op, imp.Accumulate):
         counter[op.indexsum] += 1
         recurse(op.indexsum.children[0])
+    elif isinstance(op, imp.ReturnAccumulate):
+        recurse(op.indexsum.children[0])
     else:
         raise AssertionError("unhandled operation: %s" % type(op))
 


### PR DESCRIPTION
A few optimisations that help to achieve assembly performance on par with our old FFC on affine cells:
 * Accumulating directly into the output tensor instead of using a temporary and then later copying into the output tensor.
 * Alternative mode of handling mixed element coefficients in interior facet integrals: assemble ListTensor instead "manually" generating COFFEE loops.
 * This alternative way is enabled on the coordinates on simplex cells. Combined with the previous optimisation expanding the evaluation of cellwise constant coefficients, this gives "code snippet"-equivalent code even in interior facet integrals.
 * Don't expand quadrature loops.