### PR TITLE
Lots of docstrings and minor cleanups

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
  - [ ] symbolic tabulation for cellwise constantness? (See [#15](https://github.com/firedrakeproject/tsfc/issues/15))
  - [ ] simplification in the `FormSplitter`?
 - [ ] `geometric.py`: move functionality to FIAT
-- [ ] `VariableIndex` to wrap a `gem.Expression` instead of a string
+- [X] `VariableIndex` to wrap a GEM expression instead of a string
 - [X] `optimise.py`: module docstring
 - [ ] `ufl2gem.py`: comments + docstring
 - [ ] Better `README`

--- a/TODO.md
+++ b/TODO.md
@@ -7,5 +7,5 @@
 - [ ] `geometric.py`: move functionality to FIAT
 - [X] `VariableIndex` to wrap a GEM expression instead of a string
 - [X] `optimise.py`: module docstring
-- [ ] `ufl2gem.py`: comments + docstring
+- [X] `ufl2gem.py`: comments + docstring
 - [ ] Better `README`

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 - [ ] `driver.py` cleanup
  - [ ] kernel interface separation?
-- [ ] `fem.py` docstrings
+- [X] `fem.py` docstrings
  - [ ] separation of UFL preprocessing?
  - [ ] symbolic tabulation for cellwise constantness? (See [#15](https://github.com/firedrakeproject/tsfc/issues/15))
  - [ ] simplification in the `FormSplitter`?
@@ -9,3 +9,4 @@
 - [X] `optimise.py`: module docstring
 - [X] `ufl2gem.py`: comments + docstring
 - [ ] Better `README`
+- [ ] make optimisations etc. configurable (e.g. coffee_licm, unroll_indexsums)

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,6 @@
  - [ ] simplification in the `FormSplitter`?
 - [ ] `geometric.py`: move functionality to FIAT
 - [ ] `VariableIndex` to wrap a `gem.Expression` instead of a string
-- [ ] `optimise.py`: module docstring
+- [X] `optimise.py`: module docstring
 - [ ] `ufl2gem.py`: comments + docstring
 - [ ] Better `README`

--- a/TODO.md
+++ b/TODO.md
@@ -8,5 +8,5 @@
 - [X] `VariableIndex` to wrap a GEM expression instead of a string
 - [X] `optimise.py`: module docstring
 - [X] `ufl2gem.py`: comments + docstring
-- [ ] Better `README`
-- [ ] make optimisations etc. configurable (e.g. coffee_licm, unroll_indexsums)
+- [ ] Better `README`, AUTHORS, more pedantic licensing info
+- [X] make optimisations etc. configurable (e.g. coffee_licm, unroll_indexsums)

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -266,7 +266,7 @@ def _expression_indexed(expr, parameters):
         if isinstance(index, gem.Index):
             rank.append(parameters.index_names[index])
         elif isinstance(index, gem.VariableIndex):
-            rank.append(index.name)
+            rank.append(expression(index.expression, parameters).gencode())
         else:
             rank.append(index)
     return _coffee_symbol(expression(expr.children[0], parameters),

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -13,7 +13,7 @@ from singledispatch import singledispatch
 
 import coffee.base as coffee
 
-from tsfc import gem as ein, impero as imp
+from tsfc import gem, impero as imp
 from tsfc.constants import SCALAR_TYPE, PRECISION
 
 
@@ -135,7 +135,7 @@ def statement_returnaccumulate(leaf, parameters):
 @statement.register(imp.Evaluate)
 def statement_evaluate(leaf, parameters):
     expr = leaf.expression
-    if isinstance(expr, ein.ListTensor):
+    if isinstance(expr, gem.ListTensor):
         if parameters.declare[leaf]:
             array_expression = numpy.vectorize(lambda v: expression(v, parameters))
             return coffee.Decl(SCALAR_TYPE,
@@ -148,7 +148,7 @@ def statement_evaluate(leaf, parameters):
                 coffee_sym = _coffee_symbol(_ref_symbol(expr, parameters), rank=multiindex)
                 ops.append(coffee.Assign(coffee_sym, expression(value, parameters)))
             return coffee.Block(ops, open_scope=False)
-    elif isinstance(expr, ein.Literal):
+    elif isinstance(expr, gem.Literal):
         assert parameters.declare[leaf]
         return coffee.Decl(SCALAR_TYPE,
                            _decl_symbol(expr, parameters),
@@ -182,38 +182,38 @@ def _expression(expr, parameters):
     raise AssertionError("cannot generate COFFEE from %s" % type(expr))
 
 
-@_expression.register(ein.Product)
+@_expression.register(gem.Product)
 def _expression_product(expr, parameters):
     return coffee.Prod(*[expression(c, parameters)
                          for c in expr.children])
 
 
-@_expression.register(ein.Sum)
+@_expression.register(gem.Sum)
 def _expression_sum(expr, parameters):
     return coffee.Sum(*[expression(c, parameters)
                         for c in expr.children])
 
 
-@_expression.register(ein.Division)
+@_expression.register(gem.Division)
 def _expression_division(expr, parameters):
     return coffee.Div(*[expression(c, parameters)
                         for c in expr.children])
 
 
-@_expression.register(ein.Power)
+@_expression.register(gem.Power)
 def _expression_power(expr, parameters):
     base, exponent = expr.children
     return coffee.FunCall("pow", expression(base, parameters), expression(exponent, parameters))
 
 
-@_expression.register(ein.MathFunction)
+@_expression.register(gem.MathFunction)
 def _expression_mathfunction(expr, parameters):
     name_map = {'abs': 'fabs', 'ln': 'log'}
     name = name_map.get(expr.name, expr.name)
     return coffee.FunCall(name, expression(expr.children[0], parameters))
 
 
-@_expression.register(ein.Comparison)
+@_expression.register(gem.Comparison)
 def _expression_comparison(expr, parameters):
     type_map = {">": coffee.Greater,
                 ">=": coffee.GreaterEq,
@@ -224,28 +224,28 @@ def _expression_comparison(expr, parameters):
     return type_map[expr.operator](*[expression(c, parameters) for c in expr.children])
 
 
-@_expression.register(ein.LogicalNot)
+@_expression.register(gem.LogicalNot)
 def _expression_logicalnot(expr, parameters):
     return coffee.Not(*[expression(c, parameters) for c in expr.children])
 
 
-@_expression.register(ein.LogicalAnd)
+@_expression.register(gem.LogicalAnd)
 def _expression_logicaland(expr, parameters):
     return coffee.And(*[expression(c, parameters) for c in expr.children])
 
 
-@_expression.register(ein.LogicalOr)
+@_expression.register(gem.LogicalOr)
 def _expression_logicalor(expr, parameters):
     return coffee.Or(*[expression(c, parameters) for c in expr.children])
 
 
-@_expression.register(ein.Conditional)
+@_expression.register(gem.Conditional)
 def _expression_conditional(expr, parameters):
     return coffee.Ternary(*[expression(c, parameters) for c in expr.children])
 
 
-@_expression.register(ein.Literal)
-@_expression.register(ein.Zero)
+@_expression.register(gem.Literal)
+@_expression.register(gem.Zero)
 def _expression_scalar(expr, parameters):
     assert not expr.shape
     if isnan(expr.value):
@@ -254,18 +254,18 @@ def _expression_scalar(expr, parameters):
         return coffee.Symbol(("%%.%dg" % (PRECISION - 1)) % expr.value)
 
 
-@_expression.register(ein.Variable)
+@_expression.register(gem.Variable)
 def _expression_variable(expr, parameters):
     return _coffee_symbol(expr.name)
 
 
-@_expression.register(ein.Indexed)
+@_expression.register(gem.Indexed)
 def _expression_indexed(expr, parameters):
     rank = []
     for index in expr.multiindex:
-        if isinstance(index, ein.Index):
+        if isinstance(index, gem.Index):
             rank.append(parameters.index_names[index])
-        elif isinstance(index, ein.VariableIndex):
+        elif isinstance(index, gem.VariableIndex):
             rank.append(index.name)
         else:
             rank.append(index)

--- a/tsfc/constants.py
+++ b/tsfc/constants.py
@@ -13,7 +13,9 @@ SCALAR_TYPE = {numpy.dtype("double"): "double",
 
 PARAMETERS = {
     "quadrature_rule": "auto",
-    "quadrature_degree": "auto"
+    "quadrature_degree": "auto",
+    "coffee_licm": False,
+    "unroll_indexsum": 3,
 }
 
 

--- a/tsfc/constants.py
+++ b/tsfc/constants.py
@@ -14,7 +14,17 @@ SCALAR_TYPE = {numpy.dtype("double"): "double",
 PARAMETERS = {
     "quadrature_rule": "auto",
     "quadrature_degree": "auto",
+
+    # Trust COFFEE to do loop-invariant code motion. Disabled by
+    # default as COFFEE does not work on TSFC-generated code yet.
+    # When enabled, it allows the inlining of expressions even if that
+    # pulls calculations into inner loops.
     "coffee_licm": False,
+
+    # Maximum extent to unroll index sums. Default is 3, so that loops
+    # over geometric dimensions are unrolled; this improves assembly
+    # performance.  Can be disabled by setting it to None, False or 0;
+    # that makes compilation time much shorter.
     "unroll_indexsum": 3,
 }
 

--- a/tsfc/constants.py
+++ b/tsfc/constants.py
@@ -11,8 +11,6 @@ SCALAR_TYPE = {numpy.dtype("double"): "double",
                numpy.dtype("float32"): "float"}[NUMPY_TYPE]
 
 
-RESTRICTION_MAP = {"+": 0, "-": 1}
-
 PARAMETERS = {
     "quadrature_rule": "auto",
     "quadrature_degree": "auto"

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -45,6 +45,13 @@ class Kernel(object):
 
 
 def compile_form(form, prefix="form", parameters=None):
+    """Compiles a UFL form into a set of assembly kernels.
+
+    :arg form: UFL form
+    :arg prefix: kernel name will start with this string
+    :arg parameters: parameters object
+    :returns: list of kernels
+    """
     cpu_time = time.time()
 
     assert isinstance(form, Form)
@@ -77,6 +84,14 @@ def compile_form(form, prefix="form", parameters=None):
 
 
 def compile_integral(idata, fd, prefix, parameters):
+    """Compiles a UFL integral into an assembly kernel.
+
+    :arg idata: UFL integral data
+    :arg fd: UFL form data
+    :arg prefix: kernel name will start with this string
+    :arg parameters: parameters object
+    :returns: a kernel, or None if the integral simplifies to zero
+    """
     # Remove these here, they're handled below.
     if parameters.get("quadrature_degree") == "auto":
         del parameters["quadrature_degree"]
@@ -254,6 +269,22 @@ def is_mesh_affine(mesh):
 
 
 def prepare_coefficient(integral_type, coefficient, name, mode=None):
+    """Bridges the kernel interface and the GEM abstraction for
+    Coefficients.  Mixed element Coefficients are rearranged here for
+    interior facet integrals.
+
+    :arg integral_type: integral type
+    :arg coefficient: UFL Coefficient
+    :arg name: unique name to refer to the Coefficient in the kernel
+    :arg mode: 'manual_loop' or 'list_tensor'; two ways to deal with
+               interior facet integrals on mixed elements
+    :returns: (funarg, prepare, expression)
+         funarg     - :class:`coffee.Decl` function argument
+         prepare    - list of COFFEE nodes to be prepended to the
+                      kernel body
+         expression - GEM expression referring to the Coefficient
+                      values
+    """
     if mode is None:
         mode = 'manual_loop'
 
@@ -377,6 +408,20 @@ def prepare_coefficient(integral_type, coefficient, name, mode=None):
 
 
 def prepare_arguments(integral_type, arguments):
+    """Bridges the kernel interface and the GEM abstraction for
+    Arguments.  Vector Arguments are rearranged here for interior
+    facet integrals.
+
+    :arg integral_type: integral type
+    :arg arguments: UFL Arguments
+    :returns: (funarg, prepare, expression, finalise)
+         funarg     - :class:`coffee.Decl` function argument
+         prepare    - list of COFFEE nodes to be prepended to the
+                      kernel body
+         expression - GEM expression referring to the argument tensor
+         finalise   - list of COFFEE nodes to be appended to the
+                      kernel body
+    """
     from itertools import chain, product
 
     if len(arguments) == 0:
@@ -462,6 +507,13 @@ def prepare_arguments(integral_type, arguments):
 
 
 def coffee_for(index, extent, body):
+    """Helper function to make a COFFEE loop.
+
+    :arg index: :class:`coffee.Symbol` loop index
+    :arg extent: loop extent (integer)
+    :arg body: loop body (COFFEE node)
+    :returns: COFFEE loop
+    """
     return coffee.For(coffee.Decl("int", index, init=0),
                       coffee.Less(index, extent),
                       coffee.Incr(index, 1),
@@ -469,11 +521,15 @@ def coffee_for(index, extent, body):
 
 
 def make_prefix_ordering(indices, prefix_ordering):
+    """Creates an ordering of ``indices`` which starts with those
+    indices in ``prefix_ordering``."""
     # Need to return deterministically ordered indices
     return tuple(prefix_ordering) + tuple(k for k in indices if k not in prefix_ordering)
 
 
 def make_index_orderer(index_ordering):
+    """Returns a function which given a set of indices returns those
+    indices in the order as they appear in ``index_ordering``."""
     idx2pos = {idx: pos for pos, idx in enumerate(index_ordering)}
 
     def apply_ordering(indices):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -193,7 +193,8 @@ def compile_integral(idata, fd, prefix, parameters):
                              tabulation_manager, quad_rule.weights,
                              quadrature_index, argument_indices,
                              coefficient_map, index_cache)
-        nonfem = opt.unroll_indexsum(nonfem, max_extent=3)
+        if parameters["unroll_indexsum"]:
+            nonfem = opt.unroll_indexsum(nonfem, max_extent=parameters["unroll_indexsum"])
         nonfem_.append([(gem.IndexSum(e, quadrature_index) if quadrature_index in e.free_indices else e)
                         for e in nonfem])
 
@@ -237,7 +238,7 @@ def compile_integral(idata, fd, prefix, parameters):
         return None
 
     # Drop unnecessary temporaries
-    ops = impero_utils.inline_temporaries(simplified, ops)
+    ops = impero_utils.inline_temporaries(simplified, ops, coffee_licm=parameters["coffee_licm"])
 
     # Prepare ImperoC (Impero AST + other data for code generation)
     impero_c = impero_utils.process(ops, get_indices)

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -318,6 +318,13 @@ class TabulationManager(object):
     integral types."""
 
     def __init__(self, integral_type, cell, points):
+        """Constructs a TabulationManager.
+
+        :arg integral_type: integral type
+        :arg cell: UFL cell
+        :arg points: points on the integration entity (e.g. points on
+                     an interval for facet integrals on a triangle)
+        """
         self.integral_type = integral_type
         self.points = points
 
@@ -346,6 +353,12 @@ class TabulationManager(object):
             raise NotImplementedError("integral type %s not supported" % integral_type)
 
     def tabulate(self, ufl_element, max_deriv):
+        """Prepare the tabulations of a finite element up to a given
+        derivative order.
+
+        :arg ufl_element: UFL element to tabulate
+        :arg max_deriv: tabulate derivatives up this order
+        """
         store = collections.defaultdict(list)
         for tabulator in self.tabulators:
             for c, D, table in tabulator(ufl_element, max_deriv):
@@ -403,6 +416,12 @@ class Translator(MultiFunction, ModifiedTerminalMixin, ufl2gem.Mixin):
             self.cell_orientations = gem.Variable("cell_orientations", (1, 1))
 
     def select_facet(self, tensor, restriction):
+        """Applies facet selection on a GEM tensor if necessary.
+
+        :arg tensor: GEM tensor
+        :arg restriction: restriction on the modified terminal
+        :returns: another GEM tensor
+        """
         if self.integral_type == 'cell':
             return tensor
         else:
@@ -410,6 +429,8 @@ class Translator(MultiFunction, ModifiedTerminalMixin, ufl2gem.Mixin):
             return gem.partial_indexed(tensor, (f,))
 
     def modified_terminal(self, o):
+        """Overrides the modified terminal handler from
+        :class:`ModifiedTerminalMixin`."""
         mt = analyse_modified_terminal(o)
         return translate(mt.terminal, mt, self)
 
@@ -522,11 +543,12 @@ def _(terminal, mt, params):
 
 
 def coordinate_coefficient(domain):
+    """Create a fake coordinate coefficient for a domain."""
     return ufl.Coefficient(ufl.FunctionSpace(domain, domain.ufl_coordinate_element()))
 
 
 def replace_coordinates(integrand, coordinate_coefficient):
-    # Replace SpatialCoordinate nodes with Coefficients
+    """Replace SpatialCoordinate nodes with Coefficients."""
     return map_expr_dag(ReplaceSpatialCoordinates(coordinate_coefficient), integrand)
 
 

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -384,10 +384,10 @@ class Translator(MultiFunction, ModifiedTerminalMixin, ufl2gem.Mixin):
         self.index_cache = index_cache
 
         if integral_type in ['exterior_facet', 'exterior_facet_vert']:
-            self.facet = {None: gem.VariableIndex('facet[0]')}
+            self.facet = {None: gem.VariableIndex(gem.Indexed(gem.Variable('facet', (1,)), (0,)))}
         elif integral_type in ['interior_facet', 'interior_facet_vert']:
-            self.facet = {'+': gem.VariableIndex('facet[0]'),
-                          '-': gem.VariableIndex('facet[1]')}
+            self.facet = {'+': gem.VariableIndex(gem.Indexed(gem.Variable('facet', (2,)), (0,))),
+                          '-': gem.VariableIndex(gem.Indexed(gem.Variable('facet', (2,)), (1,)))}
         elif integral_type == 'exterior_facet_bottom':
             self.facet = {None: 0}
         elif integral_type == 'exterior_facet_top':

--- a/tsfc/gem.py
+++ b/tsfc/gem.py
@@ -334,20 +334,27 @@ class Index(object):
 
 
 class VariableIndex(object):
-    def __init__(self, name):
-        self.name = name
+    """An index that is constant during a single execution of the
+    kernel, but whose value is not known at compile time."""
+
+    def __init__(self, expression):
+        assert isinstance(expression, Node)
+        assert not expression.free_indices
+        assert not expression.shape
+        self.expression = expression
 
     def __eq__(self, other):
-        """VariableIndices are equal if their names are equal."""
         if self is other:
             return True
         if type(self) is not type(other):
             return False
-        return self.name == other.name
+        return self.expression == other.expression
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __hash__(self):
-        """VariableIndices hash to the hash of their name."""
-        return hash(self.name)
+        return hash((VariableIndex, self.expression))
 
 
 class Indexed(Scalar):

--- a/tsfc/impero_utils.py
+++ b/tsfc/impero_utils.py
@@ -52,7 +52,7 @@ def inline_temporaries(expressions, ops, coffee_licm=False):
         # Prevent inlining that pulls expressions into inner loops
         for node in traversal(expressions):
             for child in node.children:
-                if child in candidates and set(child.free_indices) != set(node.free_indices):
+                if child in candidates and set(child.free_indices) < set(node.free_indices):
                     candidates.remove(child)
 
     # Filter out candidates

--- a/tsfc/interpreter.py
+++ b/tsfc/interpreter.py
@@ -239,7 +239,7 @@ def _(e, self):
             idx.append(Ellipsis)
         elif isinstance(i, gem.VariableIndex):
             # Variable index, evaluate inner expression
-            result, = evaluate(i.expression, self.bindings)
+            result, = self(i.expression)
             assert not result.tshape
             idx.append(result[()])
         else:

--- a/tsfc/interpreter.py
+++ b/tsfc/interpreter.py
@@ -238,11 +238,10 @@ def _(e, self):
             # Free index, want entire extent
             idx.append(Ellipsis)
         elif isinstance(i, gem.VariableIndex):
-            try:
-                # Variable indices must be provided in bindings
-                idx.append(self.bindings[i])
-            except KeyError:
-                raise ValueError("Binding for %s not found" % i)
+            # Variable index, evaluate inner expression
+            result, = evaluate(i.expression, self.bindings)
+            assert not result.tshape
+            idx.append(result[()])
         else:
             # Fixed index, just pick that value
             idx.append(i)
@@ -293,8 +292,8 @@ def evaluate(expressions, bindings=None):
 
     :arg expressions: A single GEM expression, or iterable of
         expressions to evaluate.
-    :kwarg bindings: An optional dict mapping GEM :class:`gem.Variable` and
-        :class:`gem.VariableIndex` nodes to data.
+    :kwarg bindings: An optional dict mapping GEM :class:`gem.Variable`
+        nodes to data.
     :returns: a list of the evaluated expressions.
     """
     try:

--- a/tsfc/optimise.py
+++ b/tsfc/optimise.py
@@ -1,3 +1,6 @@
+"""A set of routines implementing various transformations on GEM
+expressions."""
+
 from __future__ import absolute_import
 
 from singledispatch import singledispatch


### PR DESCRIPTION
Two other notable changes:
- Some compiler optimisations are now configurable
- `gem.VariableIndex` wraps GEM expressions instead of a string

The configurable options are:
- `coffee_licm`: Trust COFFEE to do LICM. Disabled by default as COFFEE doesn't work on TSFC generated code yet. When enabled, it allows the inlining of expressions even if that pull calculations into inner loops.
- `unroll_indexsum`: Maximum extent to unroll index sums. Default is 3, so that loops over geometric dimensions are unrolled; this improves assembly performance. Can be disabled by setting it to `None`, `False` or `0`; that makes compilation time much shorter.

@wence-: can you have a look at the interpreter changes?