### PR TITLE
Fix code generation for gem.IndexSum

### DIFF
--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,0 +1,26 @@
+from tsfc import driver, impero_utils, scheduling
+from tsfc.gem import Index, Indexed, IndexSum, Product, Variable
+
+
+def test_loop_fusion():
+    i = Index()
+    j = Index()
+    Ri = Indexed(Variable('R', (6,)), (i,))
+
+    def make_expression(i, j):
+        A = Variable('A', (6,))
+        s = IndexSum(Indexed(A, (j,)), j)
+        return Product(Indexed(A, (i,)), s)
+
+    e1 = make_expression(i, j)
+    e2 = make_expression(i, i)
+
+    apply_ordering = driver.make_index_orderer((i, j))
+    get_indices = lambda expr: apply_ordering(expr.free_indices)
+
+    def gencode(expr):
+        ops = scheduling.emit_operations([(Ri, expr)], get_indices)
+        impero_c = impero_utils.process(ops, get_indices)
+        return impero_c.tree
+
+    assert len(gencode(e1).children) == len(gencode(e2).children)

--- a/tsfc/impero.py
+++ b/tsfc/impero.py
@@ -82,6 +82,20 @@ class Accumulate(Terminal):
         return free_indices(self.indexsum.children[0])
 
 
+class Noop(Terminal):
+    """No-op terminal. Does not generate code, but wraps a GEM
+    expression to have a loop shape, thus affects loop fusion."""
+
+    __slots__ = ('expression',)
+    __front__ = ('expression',)
+
+    def __init__(self, expression):
+        self.expression = expression
+
+    def loop_shape(self, free_indices):
+        return free_indices(self.expression)
+
+
 class Return(Terminal):
     """Save value of GEM expression into an lvalue. Used to "return"
     values from a kernel."""

--- a/tsfc/scheduling.py
+++ b/tsfc/scheduling.py
@@ -121,6 +121,7 @@ def handle(ops, push, decref, node):
         # Indexing always inlined
         decref(node.children[0])
     elif isinstance(node, gem.IndexSum):
+        ops.append(impero.Noop(node))
         push(impero.Accumulate(node))
     elif isinstance(node, gem.Node):
         ops.append(impero.Evaluate(node))


### PR DESCRIPTION
Fixes #25, and protects the fix with a test case.

Changes:


1. A new Impero terminal `Noop` (no-op) is introduced, does nothing, but has a loop shape, thus it can prevent loop fusion. This terminal is thrown away during the construction of the Impero AST, i.e. when turning a list of Impero terminals into a tree.

2. An IndexSum over free index `r`, with free indices `(q,)`, formerly generated two Impero terminals:
   * `Initialise` with loop shape `(q,)`
   * `Accumulate` with loop shape `(q, r)`

 With this change, a third one is generated as well:
   * `Noop` with loop shape `(q,)`

 This is to guarantee that the accumulate loop is finished before the summed value is used.