### PR TITLE
Abstract base classes IndexBase and Constant

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -16,6 +16,7 @@ indices.
 
 from __future__ import absolute_import
 
+from abc import ABCMeta
 from itertools import chain
 from numpy import asarray, eye, unique
 
@@ -336,7 +337,15 @@ class Conditional(Node):
         self.shape = then.shape
 
 
-class Index(object):
+class IndexBase(object):
+    """Abstract base class for indices."""
+
+    __metaclass__ = ABCMeta
+
+IndexBase.register(int)
+
+
+class Index(IndexBase):
     """Free index"""
 
     # Not true object count, just for naming purposes
@@ -369,7 +378,7 @@ class Index(object):
         return "Index(%r)" % self.name
 
 
-class VariableIndex(object):
+class VariableIndex(IndexBase):
     """An index that is constant during a single execution of the
     kernel, but whose value is not known at compile time."""
 
@@ -401,6 +410,7 @@ class Indexed(Scalar):
         # Set index extents from shape
         assert len(aggregate.shape) == len(multiindex)
         for index, extent in zip(multiindex, aggregate.shape):
+            assert isinstance(index, IndexBase)
             if isinstance(index, Index):
                 index.set_extent(extent)
 

--- a/gem/interpreter.py
+++ b/gem/interpreter.py
@@ -99,9 +99,9 @@ def _(e, self):
     return Result(numpy.zeros(e.shape, dtype=float))
 
 
-@_evaluate.register(gem.Literal)  # noqa: not actually redefinition
+@_evaluate.register(gem.Constant)  # noqa: not actually redefinition
 def _(e, self):
-    """Literals return their array."""
+    """Constants return their array."""
     return Result(e.array)
 
 

--- a/gem/scheduling.py
+++ b/gem/scheduling.py
@@ -111,7 +111,7 @@ def handle(ops, push, decref, node):
     if isinstance(node, gem.Variable):
         # Declared in the kernel header
         pass
-    elif isinstance(node, gem.Literal):
+    elif isinstance(node, gem.Constant):
         # Constant literals inlined, unless tensor-valued
         if node.shape:
             ops.append(impero.Evaluate(node))

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -13,8 +13,7 @@ from singledispatch import singledispatch
 
 import coffee.base as coffee
 
-import gem
-import gem.impero as imp
+from gem import gem, impero as imp
 
 from tsfc.constants import SCALAR_TYPE, PRECISION
 
@@ -150,7 +149,7 @@ def statement_evaluate(leaf, parameters):
                 coffee_sym = _coffee_symbol(_ref_symbol(expr, parameters), rank=multiindex)
                 ops.append(coffee.Assign(coffee_sym, expression(value, parameters)))
             return coffee.Block(ops, open_scope=False)
-    elif isinstance(expr, gem.Literal):
+    elif isinstance(expr, gem.Constant):
         assert parameters.declare[leaf]
         return coffee.Decl(SCALAR_TYPE,
                            _decl_symbol(expr, parameters),
@@ -256,8 +255,7 @@ def _expression_conditional(expr, parameters):
     return coffee.Ternary(*[expression(c, parameters) for c in expr.children])
 
 
-@_expression.register(gem.Literal)
-@_expression.register(gem.Zero)
+@_expression.register(gem.Constant)
 def _expression_scalar(expr, parameters):
     assert not expr.shape
     if isnan(expr.value):

--- a/tsfc/ufl2gem.py
+++ b/tsfc/ufl2gem.py
@@ -6,8 +6,8 @@ import collections
 import numpy
 import ufl
 
-from gem import (Literal, Zero, Sum, Product, Division, Power,
-                 MathFunction, MinValue, MaxValue, Comparison,
+from gem import (Literal, Zero, Identity, Sum, Product, Division,
+                 Power, MathFunction, MinValue, MaxValue, Comparison,
                  LogicalNot, LogicalAnd, LogicalOr, Conditional,
                  Index, Indexed, ComponentTensor, IndexSum,
                  ListTensor)
@@ -28,7 +28,7 @@ class Mixin(object):
         return Literal(o.value())
 
     def identity(self, o):
-        return Literal(numpy.eye(*o.ufl_shape))
+        return Identity(o._dim)
 
     def zero(self, o):
         return Zero(o.ufl_shape)


### PR DESCRIPTION
Currently GEM has three types of indices:
 * `int`: fixed index
 * `VariableIndex`: indices which are constants for a single execution of the kernel, but not compile-time constant, for example: facet number.
 * `Index`: running free index, will generate a loop.

`IndexBase` is introduced by this pull request as an abstract base class for these index types.

GEM will have three types of compile-time constant nodes:
 * `Literal`: tensor of floating-point values with arbitrary shape (general case: the data is a numpy array)
 * `Zero`: special case of `Literal`, all elements are zero, thus no need to store array of all zeros
 * `Identity`: identity matrix (also a special case `Literal`, but no need store the matrix)

`Identity` is introduced by this pull request, to map Identity from UFL, and for future use with Delta.
This pull request also introduces the abstract base class `Constant`, which is the base class of `Literal`, `Identity` and `Zero`.

The reason I typed also these out, it that if some of the names are misleading, better suggestions are welcome.