### PR TITLE
Split mixed coefficients

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -123,6 +123,7 @@ def compile_integral(integral_data, form_data, prefix, parameters):
                              type(quad_rule))
 
         integrand = ufl_utils.replace_coordinates(integral.integrand(), coordinates)
+        integrand = ufl_utils.split_coefficients(integrand, builder.coefficient_split)
         quadrature_index = gem.Index(name='ip')
         quadrature_indices.append(quadrature_index)
         ir = fem.process(integral_type, cell, quad_rule.points,

--- a/tsfc/modified_terminals.py
+++ b/tsfc/modified_terminals.py
@@ -23,6 +23,7 @@
 from __future__ import print_function  # used in some debugging
 
 from ufl.classes import (ReferenceValue, ReferenceGrad,
+                         NegativeRestricted, PositiveRestricted,
                          Restricted, FacetAvg, CellAvg)
 
 
@@ -161,3 +162,27 @@ def analyse_modified_terminal(expr):
         raise ValueError("Local derivatives of non-local value?")
 
     return mt
+
+
+def construct_modified_terminal(mt, terminal):
+    """Construct a modified terminal given terminal modifiers from an
+    analysed modified terminal and a terminal."""
+    expr = terminal
+
+    if mt.reference_value:
+        expr = ReferenceValue(expr)
+
+    for n in range(mt.local_derivatives):
+        expr = ReferenceGrad(expr)
+
+    if mt.averaged == "cell":
+        expr = CellAvg(expr)
+    elif mt.averaged == "facet":
+        expr = FacetAvg(expr)
+
+    if mt.restriction == '+':
+        expr = PositiveRestricted(expr)
+    elif mt.restriction == '-':
+        expr = NegativeRestricted(expr)
+
+    return expr


### PR DESCRIPTION
This will become useful to support mixed problems with FInAT, but I think the change is solid enough to go directly to master.

After this change, `tsfc.MixedElement` (formerly known as `ffc.MixedElement`) will only be used to implement `ufl.VectorElement`s and `ufl.TensorElement`, because actual mixed coefficients are split.

This changes the kernel contract between TSFC and "PyOP2", so it must be merged at the same time as firedrakeproject/firedrake#775.