### PR TITLE
fem: Handle ConstantValue in modified terminal translation

### DIFF
--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -8,8 +8,9 @@ from singledispatch import singledispatch
 
 from ufl.corealg.map_dag import map_expr_dag, map_expr_dags
 from ufl.corealg.multifunction import MultiFunction
-from ufl.classes import (Argument, Coefficient, FormArgument,
-                         GeometricQuantity, QuadratureWeight)
+from ufl.classes import (Argument, Coefficient, ConstantValue,
+                         FormArgument, GeometricQuantity,
+                         QuadratureWeight)
 
 import gem
 
@@ -326,6 +327,13 @@ def _(terminal, mt, params):
                                         gem.Indexed(ka, (r,))), r)
 
     return iterate_shape(mt, callback)
+
+
+@translate.register(ConstantValue)
+def _translate_constantvalue(terminal, mt, params):
+    # Literal in a modified terminal
+    # Terminal modifiers have no effect, just translate the terminal.
+    return params(terminal)
 
 
 def process(integral_type, cell, points, weights, quadrature_index,


### PR DESCRIPTION
Could happen if zero-simplification in UFL didn't pick up that we had
grad of a cellwise constant sub coefficient in a mixed form.  Fixes #41.