### PR TITLE
CellVolume and FacetArea

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,12 @@
 - [ ] `driver.py` cleanup
- - [X] kernel interface separation?
- - [ ] clean up around the `fem.process` call
-- [X] `fem.py` docstrings
- - [ ] separation of UFL preprocessing?
-   - [X] separate `ufl_utils.py`
+ - [X] clean up around the `fem.process` call
+- UFL to GEM:
+ - [ ] Re-think translation context
  - [ ] symbolic tabulation for cellwise constantness? (See [#15](https://github.com/firedrakeproject/tsfc/issues/15))
  - [ ] simplification in the `FormSplitter`?
    - [X] on branch for new H(div) trace element
 - [ ] `geometric.py`: move functionality to FIAT
 - [ ] split `compile_gem`: Impero AST, ImperoC
-- [ ] `gem.py`: common base class for indices, make `Zero` a "`Literal`"
+- [X] `gem.py`: common base class for indices, make `Zero` a "`Literal`"
 - [ ] Better `README`, AUTHORS, more pedantic licensing info
+- [ ] refactor CellVolue / FacetArea

--- a/tests/test_create_quadrature.py
+++ b/tests/test_create_quadrature.py
@@ -37,24 +37,6 @@ def test_select_degree(cell, degree, itype):
 
 
 @pytest.mark.parametrize("degree",
-                         [(1, 1), (2, 2)])
-@pytest.mark.parametrize("itype",
-                         ["interior_facet", "exterior_facet"])
-def test_select_degree_facet_quad(degree, itype):
-    selected = q.select_degree(degree, ufl.quadrilateral, itype)
-    assert selected == degree[0]
-
-
-@pytest.mark.parametrize("degree",
-                         [(1, 2), (2,)])
-@pytest.mark.parametrize("itype",
-                         ["interior_facet", "exterior_facet"])
-def test_select_invalid_degree_facet_quad(degree, itype):
-    with pytest.raises(ValueError):
-        q.select_degree(degree, ufl.quadrilateral, itype)
-
-
-@pytest.mark.parametrize("degree",
                          [(1, 2), (2, 3)])
 @pytest.mark.parametrize("itype",
                          ["interior_facet_horiz", "exterior_facet_top",

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import collections
 import time
 
-from ufl.classes import Form
+from ufl.classes import Form, CellVolume, FacetArea
 from ufl.algorithms import compute_form_data
 from ufl.log import GREEN
 
@@ -42,6 +42,7 @@ def compile_form(form, prefix="form", parameters=None):
                            do_apply_integral_scaling=True,
                            do_apply_geometry_lowering=True,
                            do_apply_restrictions=True,
+                           preserve_geometry_types=(CellVolume, FacetArea),
                            do_estimate_degrees=True)
     print GREEN % ("compute_form_data finished in %g seconds." % (time.time() - cpu_time))
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -103,6 +103,7 @@ def compile_integral(integral_data, form_data, prefix, parameters):
     # evaluation can be hoisted).
     index_cache = collections.defaultdict(gem.Index)
 
+    # TODO: refactor this!
     def cellvolume(restriction):
         from ufl import dx
         form = 1 * dx(domain=mesh)
@@ -140,6 +141,7 @@ def compile_integral(integral_data, form_data, prefix, parameters):
             expr = gem.IndexSum(expr, quadrature_index)
         return expr
 
+    # TODO: refactor this!
     def facetarea():
         from ufl import Measure
         assert integral_type != 'cell'

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -192,6 +192,7 @@ class FacetManager(object):
             return gem.partial_indexed(tensor, (f,))
 
 
+# FIXME: copy-paste from PyOP2
 class cached_property(object):
     """A read-only @property that is only evaluated once. The value is cached
     on the object itself rather than the function or class; this should prevent

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -17,6 +17,7 @@ import gem
 from tsfc.constants import PRECISION
 from tsfc.fiatinterface import create_element, as_fiat_cell
 from tsfc.modified_terminals import analyse_modified_terminal
+from tsfc.quadrature import create_quadrature
 from tsfc import compat
 from tsfc import ufl2gem
 from tsfc import geometric
@@ -191,38 +192,89 @@ class FacetManager(object):
             return gem.partial_indexed(tensor, (f,))
 
 
+class cached_property(object):
+    """A read-only @property that is only evaluated once. The value is cached
+    on the object itself rather than the function or class; this should prevent
+    memory leakage."""
+    def __init__(self, fget, doc=None):
+        self.fget = fget
+        self.__doc__ = doc or fget.__doc__
+        self.__name__ = fget.__name__
+        self.__module__ = fget.__module__
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+        obj.__dict__[self.__name__] = result = self.fget(obj)
+        return result
+
+
+class Parameters(object):
+    keywords = ('integral_type',
+                'cell',
+                'quadrature_degree',
+                'quadrature_rule',
+                'points',
+                'weights',
+                'point_index',
+                'argument_indices',
+                'coefficient_mapper',
+                'cellvolume',
+                'facetarea',
+                'index_cache')
+
+    def __init__(self, **kwargs):
+        invalid_keywords = set(kwargs.keys()) - set(Parameters.keywords)
+        if invalid_keywords:
+            raise ValueError("unexpected keyword argument '{0}'".format(invalid_keywords.pop()))
+        self.__dict__.update(kwargs)
+
+    # Defaults
+    integral_type = 'cell'
+
+    @cached_property
+    def quadrature_rule(self):
+        return create_quadrature(self.cell,
+                                 self.integral_type,
+                                 self.quadrature_degree)
+
+    @cached_property
+    def points(self):
+        return self.quadrature_rule.points
+
+    @cached_property
+    def weights(self):
+        return self.quadrature_rule.weights
+
+    argument_indices = ()
+
+    @cached_property
+    def index_cache(self):
+        return collections.defaultdict(gem.Index)
+
+
 class Translator(MultiFunction, ModifiedTerminalMixin, ufl2gem.Mixin):
     """Contains all the context necessary to translate UFL into GEM."""
 
-    def __init__(self, tabulation_manager, weights, quadrature_index,
-                 argument_indices, coefficient_mapper, index_cache,
-                 cellvolume, facetarea):
+    def __init__(self, tabulation_manager, parameters):
         MultiFunction.__init__(self)
         ufl2gem.Mixin.__init__(self)
-        integral_type = tabulation_manager.integral_type
-        facet_manager = tabulation_manager.facet_manager
-        self.integral_type = integral_type
-        self.tabulation_manager = tabulation_manager
-        self.weights = gem.Literal(weights)
-        self.quadrature_index = quadrature_index
-        self.argument_indices = argument_indices
-        self.coefficient_mapper = coefficient_mapper
-        self.index_cache = index_cache
-        self.facet_manager = facet_manager
-        self.select_facet = facet_manager.select_facet
-        self.cellvolume = cellvolume
-        self.facetarea = facetarea
 
-        if self.integral_type.startswith("interior_facet"):
-            self.cell_orientations = gem.Variable("cell_orientations", (2, 1))
+        if parameters.integral_type.startswith("interior_facet"):
+            parameters.cell_orientations = gem.Variable("cell_orientations", (2, 1))
         else:
-            self.cell_orientations = gem.Variable("cell_orientations", (1, 1))
+            parameters.cell_orientations = gem.Variable("cell_orientations", (1, 1))
+
+        parameters.tabulation_manager = tabulation_manager
+        parameters.facet_manager = tabulation_manager.facet_manager
+        parameters.select_facet = tabulation_manager.facet_manager.select_facet
+        self.parameters = parameters
 
     def modified_terminal(self, o):
         """Overrides the modified terminal handler from
         :class:`ModifiedTerminalMixin`."""
         mt = analyse_modified_terminal(o)
-        return translate(mt.terminal, mt, self)
+        return translate(mt.terminal, mt, self.parameters)
 
 
 def iterate_shape(mt, callback):
@@ -273,18 +325,18 @@ def translate(terminal, mt, params):
     raise AssertionError("Cannot handle terminal type: %s" % type(terminal))
 
 
-@translate.register(QuadratureWeight)  # noqa: Not actually redefinition
-def _(terminal, mt, params):
-    return gem.Indexed(params.weights, (params.quadrature_index,))
+@translate.register(QuadratureWeight)
+def translate_quadratureweight(terminal, mt, params):
+    return gem.Indexed(gem.Literal(params.weights), (params.point_index,))
 
 
-@translate.register(GeometricQuantity)  # noqa: Not actually redefinition
-def _(terminal, mt, params):
+@translate.register(GeometricQuantity)
+def translate_geometricquantity(terminal, mt, params):
     return geometric.translate(terminal, mt, params)
 
 
-@translate.register(CellVolume)  # noqa: Not actually redefinition
-def _(terminal, mt, params):
+@translate.register(CellVolume)
+def translate_cellvolume(terminal, mt, params):
     return params.cellvolume(mt.restriction)
 
 
@@ -293,8 +345,8 @@ def translate_facetarea(terminal, mt, params):
     return params.facetarea()
 
 
-@translate.register(Argument)  # noqa: Not actually redefinition
-def _(terminal, mt, params):
+@translate.register(Argument)
+def translate_argument(terminal, mt, params):
     argument_index = params.argument_indices[terminal.number()]
 
     def callback(key):
@@ -304,14 +356,14 @@ def _(terminal, mt, params):
             row = gem.Literal(table)
         else:
             table = params.select_facet(gem.Literal(table), mt.restriction)
-            row = gem.partial_indexed(table, (params.quadrature_index,))
+            row = gem.partial_indexed(table, (params.point_index,))
         return gem.Indexed(row, (argument_index,))
 
     return iterate_shape(mt, callback)
 
 
-@translate.register(Coefficient)  # noqa: Not actually redefinition
-def _(terminal, mt, params):
+@translate.register(Coefficient)
+def translate_coefficient(terminal, mt, params):
     kernel_arg = params.coefficient_mapper(terminal)
 
     if terminal.ufl_element().family() == 'Real':
@@ -333,7 +385,7 @@ def _(terminal, mt, params):
                               gem.Zero())
         else:
             table = params.select_facet(gem.Literal(table), mt.restriction)
-            row = gem.partial_indexed(table, (params.quadrature_index,))
+            row = gem.partial_indexed(table, (params.point_index,))
 
         r = params.index_cache[terminal.ufl_element()]
         return gem.IndexSum(gem.Product(gem.Indexed(row, (r,)),
@@ -349,15 +401,15 @@ def _translate_constantvalue(terminal, mt, params):
     return params(terminal)
 
 
-def process(integral_type, cell, points, weights, quadrature_index,
-            argument_indices, integrand, coefficient_mapper,
-            index_cache, cellvolume, facetarea):
+def compile_ufl(expression, **kwargs):
+    params = Parameters(**kwargs)
+
     # Abs-simplification
-    integrand = simplify_abs(integrand)
+    expression = simplify_abs(expression)
 
     # Collect modified terminals
     modified_terminals = []
-    map_expr_dag(CollectModifiedTerminals(modified_terminals), integrand)
+    map_expr_dag(CollectModifiedTerminals(modified_terminals), expression)
 
     # Collect maximal derivatives that needs tabulation
     max_derivs = collections.defaultdict(int)
@@ -368,21 +420,18 @@ def process(integral_type, cell, points, weights, quadrature_index,
             max_derivs[ufl_element] = max(mt.local_derivatives, max_derivs[ufl_element])
 
     # Collect tabulations for all components and derivatives
-    tabulation_manager = TabulationManager(integral_type, cell, points)
+    tabulation_manager = TabulationManager(params.integral_type, params.cell, params.points)
     for ufl_element, max_deriv in max_derivs.items():
         if ufl_element.family() != 'Real':
             tabulation_manager.tabulate(ufl_element, max_deriv)
 
-    if integral_type.startswith("interior_facet"):
+    if params.integral_type.startswith("interior_facet"):
         expressions = []
-        for rs in itertools.product(("+", "-"), repeat=len(argument_indices)):
-            expressions.append(map_expr_dag(PickRestriction(*rs), integrand))
+        for rs in itertools.product(("+", "-"), repeat=len(params.argument_indices)):
+            expressions.append(map_expr_dag(PickRestriction(*rs), expression))
     else:
-        expressions = [integrand]
+        expressions = [expression]
 
-    # Translate UFL to Einstein's notation,
-    # lowering finite element specific nodes
-    translator = Translator(tabulation_manager, weights,
-                            quadrature_index, argument_indices,
-                            coefficient_mapper, index_cache, cellvolume, facetarea)
+    # Translate UFL to GEM, lowering finite element specific nodes
+    translator = Translator(tabulation_manager, params)
     return map_expr_dags(translator, expressions)

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -284,7 +284,7 @@ def _(terminal, mt, params):
 
 @translate.register(CellVolume)  # noqa: Not actually redefinition
 def _(terminal, mt, params):
-    return params.cellvolume()
+    return params.cellvolume(mt.restriction)
 
 
 @translate.register(Argument)  # noqa: Not actually redefinition

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -204,11 +204,11 @@ def translate_cell_coordinate(terminal, mt, params):
         points = list(params.facet_manager.facet_transform(points))
     return gem.partial_indexed(params.select_facet(gem.Literal(points),
                                                    mt.restriction),
-                               (params.quadrature_index,))
+                               (params.point_index,))
 
 
 @translate.register(FacetCoordinate)
 def translate_facet_coordinate(terminal, mt, params):
     assert params.integral_type != 'cell'
     points = params.tabulation_manager.points
-    return gem.partial_indexed(gem.Literal(points), (params.quadrature_index,))
+    return gem.partial_indexed(gem.Literal(points), (params.point_index,))

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -11,7 +11,7 @@ from ufl import TensorProductCell
 from ufl.classes import (CellCoordinate, CellEdgeVectors,
                          CellFacetJacobian, CellOrientation,
                          FacetCoordinate, ReferenceCellVolume,
-                         ReferenceNormal)
+                         ReferenceFacetVolume, ReferenceNormal)
 
 import gem
 
@@ -33,6 +33,14 @@ reference_cell_volume = {
     interval_x_interval: 1.0,
     triangle_x_interval: 1.0/2.0,
     quadrilateral_x_interval: 1.0,
+}
+
+
+# Volume of the reference cells of facets
+reference_facet_volume = {
+    interval: 1.0,
+    triangle: 1.0,
+    tetrahedron: 1.0/2.0,
 }
 
 
@@ -153,6 +161,11 @@ def translate_cell_orientation(terminal, mt, params):
 @translate.register(ReferenceCellVolume)
 def translate_reference_cell_volume(terminal, mt, params):
     return gem.Literal(reference_cell_volume[reference_cell(terminal)])
+
+
+@translate.register(ReferenceFacetVolume)
+def translate_reference_facet_volume(terminal, mt, params):
+    return gem.Literal(reference_facet_volume[reference_cell(terminal)])
 
 
 @translate.register(CellFacetJacobian)

--- a/tsfc/quadrature.py
+++ b/tsfc/quadrature.py
@@ -391,19 +391,14 @@ def select_degree(degree, cell, integral_type):
             raise ValueError("Integral type '%s' invalid for cell '%s'" %
                              (integral_type, cell.cellname()))
         if cell.cellname() == "quadrilateral":
-            try:
-                d1, d2 = degree
-                if len(degree) != 2:
-                    raise ValueError("Expected tuple degree of length 2")
-                if d1 != d2:
-                    raise ValueError("tuple degree must have matching values")
-                return d1
-            except TypeError:
-                return degree
+            assert isinstance(degree, int)
         return degree
     if not isinstance(cell, ufl.TensorProductCell):
         raise ValueError("Integral type '%s' invalid for cell '%s'" %
                          (integral_type, cell.cellname()))
+    # Fix degree on TensorProductCell when not tuple
+    if degree == 0:
+        degree = (0, 0)
     if integral_type in ("exterior_facet_top", "exterior_facet_bottom",
                          "interior_facet_horiz"):
         return degree[0]


### PR DESCRIPTION
Implements `CellVolume` and `FacetArea` for all supported cell types, including non-affine. Higher-order cells are still under-integrated, but that will be fixed by [upstream UFL](https://bitbucket.org/fenics-project/ufl/issues/80/degree-estimation-doesnt-cater-for-non).

Must be merged at the same time with firedrakeproject/firedrake#800.