### PR TITLE
Reference geometry improvements

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,3 +1,2 @@
 numpy
 singledispatch
-sympy

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,2 +1,3 @@
 numpy
 singledispatch
+sympy

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gem import impero_utils
 from gem.gem import Index, Indexed, IndexSum, Product, Variable
 
@@ -20,3 +22,9 @@ def test_loop_fusion():
         return impero_c.tree
 
     assert len(gencode(e1).children) == len(gencode(e2).children)
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import, print_function, division
+
+import pytest
+import numpy as np
+
+from FIAT.reference_element import UFCInterval, UFCTriangle, UFCTetrahedron
+from FIAT.reference_element import FiredrakeQuadrilateral, TensorProductCell
+
+from tsfc.geometric import make_cell_facet_jacobian
+
+interval = UFCInterval()
+triangle = UFCTriangle()
+quadrilateral = FiredrakeQuadrilateral()
+tetrahedron = UFCTetrahedron()
+interval_x_interval = TensorProductCell(interval, interval)
+triangle_x_interval = TensorProductCell(triangle, interval)
+quadrilateral_x_interval = TensorProductCell(quadrilateral, interval)
+
+
+@pytest.mark.parametrize(('cell', 'cell_facet_jacobian'),
+                         [(interval, [[],
+                                      []]),
+                          (triangle, [[-1, 1],
+                                      [0, 1],
+                                      [1, 0]]),
+                          (quadrilateral, [[0, 1],
+                                           [0, 1],
+                                           [1, 0],
+                                           [1, 0]]),
+                          (tetrahedron, [[-1, -1, 1, 0, 0, 1],
+                                         [0, 0, 1, 0, 0, 1],
+                                         [1, 0, 0, 0, 0, 1],
+                                         [1, 0, 0, 1, 0, 0]])])
+def test_cell_facet_jacobian(cell, cell_facet_jacobian):
+    facet_dim = cell.get_spatial_dimension() - 1
+    for facet_number in range(len(cell.get_topology()[facet_dim])):
+        actual = make_cell_facet_jacobian(cell, facet_dim, facet_number)
+        expected = np.reshape(cell_facet_jacobian[facet_number], actual.shape)
+        assert np.allclose(expected, actual)
+
+
+@pytest.mark.parametrize(('cell', 'cell_facet_jacobian'),
+                         [(interval_x_interval, [1, 0]),
+                          (triangle_x_interval, [1, 0, 0, 1, 0, 0]),
+                          (quadrilateral_x_interval, [[1, 0, 0, 1, 0, 0]])])
+def test_cell_facet_jacobian_horiz(cell, cell_facet_jacobian):
+    dim = cell.get_spatial_dimension()
+
+    actual = make_cell_facet_jacobian(cell, (dim - 1, 0), 0)  # bottom facet
+    assert np.allclose(np.reshape(cell_facet_jacobian, actual.shape), actual)
+
+    actual = make_cell_facet_jacobian(cell, (dim - 1, 0), 1)  # top facet
+    assert np.allclose(np.reshape(cell_facet_jacobian, actual.shape), actual)
+
+
+@pytest.mark.parametrize(('cell', 'cell_facet_jacobian'),
+                         [(interval_x_interval, [[0, 1],
+                                                 [0, 1]]),
+                          (triangle_x_interval, [[-1, 0, 1, 0, 0, 1],
+                                                 [0, 0, 1, 0, 0, 1],
+                                                 [1, 0, 0, 0, 0, 1]]),
+                          (quadrilateral_x_interval, [[0, 0, 1, 0, 0, 1],
+                                                      [0, 0, 1, 0, 0, 1],
+                                                      [1, 0, 0, 0, 0, 1],
+                                                      [1, 0, 0, 0, 0, 1]])])
+def test_cell_facet_jacobian_vert(cell, cell_facet_jacobian):
+    dim = cell.get_spatial_dimension()
+    vert_dim = (dim - 2, 1)
+    for facet_number in range(len(cell.get_topology()[vert_dim])):
+        actual = make_cell_facet_jacobian(cell, vert_dim, facet_number)
+        expected = np.reshape(cell_facet_jacobian[facet_number], actual.shape)
+        assert np.allclose(expected, actual)
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -168,6 +168,7 @@ def compile_integral(integral_data, form_data, prefix, parameters):
         ir = fem.compile_ufl(integrand,
                              integral_type=integral_type,
                              integration_dim=integration_dim,
+                             entity_ids=entity_ids,
                              cell=cell,
                              quadrature_degree=quadrature_degree,
                              point_index=quadrature_index,

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -129,8 +129,8 @@ def compile_integral(integral_data, form_data, prefix, parameters):
         quadrature_index = gem.Index(name='q')
         if interior_facet:
             def coefficient(ufl_coefficient, r):
-                return gem.partial_indexed(builder.coefficient(ufl_coefficient, r),
-                                           ({'+': 0, '-': 1}[restriction],))
+                assert r is None
+                return builder.coefficient(ufl_coefficient, restriction)
         else:
             assert restriction is None
             coefficient = builder.coefficient

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -15,7 +15,7 @@ from tsfc import fem, ufl_utils
 from tsfc.coffee import generate as generate_coffee
 from tsfc.constants import default_parameters
 from tsfc.fiatinterface import QuadratureRule, as_fiat_cell, create_quadrature
-from tsfc.kernel_interface import KernelBuilder, needs_cell_orientations
+from tsfc.kernel_interface import KernelInterface, KernelBuilder, needs_cell_orientations
 from tsfc.logging import logger
 
 
@@ -76,6 +76,7 @@ def compile_integral(integral_data, form_data, prefix, parameters):
         del parameters["quadrature_rule"]
 
     integral_type = integral_data.integral_type
+    interior_facet = integral_type.startswith("interior_facet")
     mesh = integral_data.domain
     cell = integral_data.domain.ufl_cell()
     arguments = form_data.preprocessed_form.arguments()
@@ -126,17 +127,30 @@ def compile_integral(integral_data, form_data, prefix, parameters):
 
         integrand = ufl_utils.replace_coordinates(integral.integrand(), coordinates)
         quadrature_index = gem.Index(name='q')
-        if integral_type.startswith("interior_facet"):
-            def coefficient_mapper(coefficient):
-                return gem.partial_indexed(builder.coefficient_mapper(coefficient), ({'+': 0, '-': 1}[restriction],))
+        if interior_facet:
+            class KIT(KernelInterface):
+                def __init__(self, parent):
+                    self.parent = parent
+
+                def coefficient(self, ufl_coefficient, r):
+                    return gem.partial_indexed(self.parent.coefficient(ufl_coefficient, r),
+                                               ({'+': 0, '-': 1}[restriction],))
+
+                def cell_orientation(self, restriction):
+                    return self.parent.cell_orientation(restriction)
+
+                def facet_number(self, restriction):
+                    return self.parent.facet_number(restriction)
+
+            ki = KIT(builder)
         else:
             assert restriction is None
-            coefficient_mapper = builder.coefficient_mapper
+            ki = builder
         ir = fem.compile_ufl(integrand,
                              cell=cell,
                              quadrature_degree=quadrature_degree,
                              point_index=quadrature_index,
-                             coefficient_mapper=coefficient_mapper,
+                             kernel_interface=ki,
                              index_cache=index_cache)
         if parameters["unroll_indexsum"]:
             ir = opt.unroll_indexsum(ir, max_extent=parameters["unroll_indexsum"])
@@ -166,13 +180,12 @@ def compile_integral(integral_data, form_data, prefix, parameters):
         integrand = ufl_utils.replace_coordinates(integral.integrand(), coordinates)
         quadrature_index = gem.Index(name='q')
         ir = fem.compile_ufl(integrand,
-                             integral_type=integral_type,
+                             cell=cell,
                              integration_dim=integration_dim,
                              entity_ids=entity_ids,
-                             cell=cell,
                              quadrature_degree=quadrature_degree,
                              point_index=quadrature_index,
-                             coefficient_mapper=builder.coefficient_mapper,
+                             kernel_interface=builder,
                              index_cache=index_cache)
         if parameters["unroll_indexsum"]:
             ir = opt.unroll_indexsum(ir, max_extent=parameters["unroll_indexsum"])
@@ -207,14 +220,14 @@ def compile_integral(integral_data, form_data, prefix, parameters):
         quadrature_index = gem.Index(name='ip')
         quadrature_indices.append(quadrature_index)
         ir = fem.compile_ufl(integrand,
-                             integral_type=integral_type,
+                             interior_facet=interior_facet,
                              cell=cell,
                              integration_dim=integration_dim,
                              entity_ids=entity_ids,
                              quadrature_rule=quad_rule,
                              point_index=quadrature_index,
                              argument_indices=argument_indices,
-                             coefficient_mapper=builder.coefficient_mapper,
+                             kernel_interface=builder,
                              index_cache=index_cache,
                              cellvolume=cellvolume,
                              facetarea=facetarea)

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -84,8 +84,9 @@ class TabulationManager(object):
     def __init__(self, entity_points):
         """Constructs a TabulationManager.
 
-        :arg points: points on the integration entity (e.g. points on
-                     an interval for facet integrals on a triangle)
+        :arg entity_points: An array of points in cell coordinates for
+                            each integration entity, i.e. an iterable
+                            of arrays of points.
         """
         self.tabulators = map(make_tabulator, entity_points)
         self.tables = {}
@@ -181,7 +182,8 @@ class Parameters(object):
 
     @cached_property
     def entity_points(self):
-        """Points in cell coordinates for each entity."""
+        """An array of points in cell coordinates for each entity,
+        i.e. a list of arrays of points."""
         result = []
         for entity_id in self.entity_ids:
             t = self.fiat_cell.get_entity_transform(self.integration_dim, entity_id)
@@ -189,6 +191,8 @@ class Parameters(object):
         return result
 
     def _selector(self, callback, opts, restriction):
+        """Helper function for selecting code for the correct entity
+        at run-time."""
         if len(opts) == 1:
             return callback(opts[0])
         else:
@@ -197,9 +201,30 @@ class Parameters(object):
             return gem.partial_indexed(results, (f,))
 
     def entity_selector(self, callback, restriction):
+        """Selects code for the correct entity at run-time.  Callback
+        generates code for a specified entity.
+
+        This function passes ``callback`` the entity number.
+
+        :arg callback: A function to be called with an entity number
+                       that generates code for that entity.
+        :arg restriction: Restriction of the modified terminal, used
+                          for entity selection.
+        """
         return self._selector(callback, self.entity_ids, restriction)
 
     def index_selector(self, callback, restriction):
+        """Selects code for the correct entity at run-time.  Callback
+        generates code for a specified entity.
+
+        This function passes ``callback`` an index of the entity
+        numbers array.
+
+        :arg callback: A function to be called with an entity index
+                       that generates code for that entity.
+        :arg restriction: Restriction of the modified terminal, used
+                          for entity selection.
+        """
         return self._selector(callback, range(len(self.entity_ids)), restriction)
 
     argument_indices = ()

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -143,7 +143,9 @@ class Parameters(object):
                 'weights',
                 'point_index',
                 'argument_indices',
-                'kernel_interface',
+                'coefficient',
+                'cell_orientation',
+                'facet_number',
                 'cellvolume',
                 'facetarea',
                 'index_cache')
@@ -191,7 +193,7 @@ class Parameters(object):
             return callback(opts[0])
         else:
             results = gem.ListTensor(map(callback, opts))
-            f = self.kernel_interface.facet_number(restriction)
+            f = self.facet_number(restriction)
             return gem.partial_indexed(results, (f,))
 
     def entity_selector(self, callback, restriction):
@@ -311,7 +313,7 @@ def translate_argument(terminal, mt, params):
 
 @translate.register(Coefficient)
 def translate_coefficient(terminal, mt, params):
-    vec = params.kernel_interface.coefficient(terminal, mt.restriction)
+    vec = params.coefficient(terminal, mt.restriction)
 
     if terminal.ufl_element().family() == 'Real':
         assert mt.local_derivatives == 0

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -95,10 +95,7 @@ def translate_cell_edge_vectors(terminal, mt, params):
 
 @translate.register(CellCoordinate)
 def translate_cell_coordinate(terminal, mt, params):
-    points = params.tabulation_manager.points
-    if params.integral_type != 'cell':
-        points = list(params.facet_manager.facet_transform(points))
-    return gem.partial_indexed(params.select_facet(gem.Literal(points),
+    return gem.partial_indexed(params.select_facet(gem.Literal(params.entity_points),
                                                    mt.restriction),
                                (params.point_index,))
 
@@ -106,5 +103,5 @@ def translate_cell_coordinate(terminal, mt, params):
 @translate.register(FacetCoordinate)
 def translate_facet_coordinate(terminal, mt, params):
     assert params.integral_type != 'cell'
-    points = params.tabulation_manager.points
+    points = params.points
     return gem.partial_indexed(gem.Literal(points), (params.point_index,))

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -7,8 +7,6 @@ from numpy import array, nan, vstack
 from singledispatch import singledispatch
 import sympy
 
-from ufl import interval, triangle, quadrilateral, tetrahedron
-from ufl import TensorProductCell
 from ufl.classes import (CellCoordinate, CellEdgeVectors,
                          CellFacetJacobian, CellOrientation,
                          FacetCoordinate, ReferenceCellVolume,
@@ -17,70 +15,6 @@ from ufl.classes import (CellCoordinate, CellEdgeVectors,
 import gem
 
 from tsfc.constants import NUMPY_TYPE
-from tsfc.fiatinterface import as_fiat_cell
-
-
-interval_x_interval = TensorProductCell(interval, interval)
-triangle_x_interval = TensorProductCell(triangle, interval)
-quadrilateral_x_interval = TensorProductCell(quadrilateral, interval)
-
-
-# Facet normals of the reference cells
-reference_normal = {
-    interval: array([[-1.0],
-                     [1.0]], dtype=NUMPY_TYPE),
-    triangle: array([[1.0, 1.0],
-                     [-1.0, 0.0],
-                     [0.0, -1.0]], dtype=NUMPY_TYPE),
-    quadrilateral: array([[-1.0, 0.0],
-                          [1.0, 0.0],
-                          [0.0, -1.0],
-                          [0.0, 1.0]], dtype=NUMPY_TYPE),
-    tetrahedron: array([[1.0, 1.0, 1.0],
-                        [-1.0, 0.0, 0.0],
-                        [0.0, -1.0, 0.0],
-                        [0.0, 0.0, -1.0]], dtype=NUMPY_TYPE),
-    # Product cells. Convention:
-    # Bottom, top, then vertical facets in the order of the base cell
-    interval_x_interval: array([[0.0, -1.0],
-                                [0.0, 1.0],
-                                [-1.0, 0.0],
-                                [1.0, 0.0]], dtype=NUMPY_TYPE),
-    triangle_x_interval: array([[0.0, 0.0, -1.0],
-                                [0.0, 0.0, 1.0],
-                                [1.0, 1.0, 0.0],
-                                [-1.0, 0.0, 0.0],
-                                [0.0, -1.0, 0.0]], dtype=NUMPY_TYPE),
-    quadrilateral_x_interval: array([[0.0, 0.0, -1.0],
-                                     [0.0, 0.0, 1.0],
-                                     [-1.0, 0.0, 0.0],
-                                     [1.0, 0.0, 0.0],
-                                     [0.0, -1.0, 0.0],
-                                     [0.0, 1.0, 0.0]], dtype=NUMPY_TYPE),
-}
-
-
-def reference_cell(terminal):
-    """Reference cell of terminal"""
-    cell = terminal.ufl_domain().ufl_cell()
-    return cell.reconstruct(geometric_dimension=cell.topological_dimension())
-
-
-def strip_table(table, integral_type):
-    """Select horizontal or vertical parts for facet integrals on
-    extruded cells. No-op in all other cases."""
-    if integral_type == "exterior_facet_bottom":
-        return table[0:1]
-    elif integral_type == "exterior_facet_top":
-        return table[1:2]
-    elif integral_type == "interior_facet_horiz":
-        # Bottom and top
-        return table[:2]
-    elif integral_type in ["exterior_facet_vert", "interior_facet_vert"]:
-        # Vertical facets in the order of the base cell
-        return table[2:]
-    else:
-        return table
 
 
 @singledispatch
@@ -139,16 +73,17 @@ def translate_cell_facet_jacobian(terminal, mt, params):
 
 @translate.register(ReferenceNormal)
 def translate_reference_normal(terminal, mt, params):
-    table = reference_normal[reference_cell(terminal)]
-    table = strip_table(table, params.integral_type)
-    table = table.reshape(table.shape[:1] + terminal.ufl_shape)
-    return params.select_facet(gem.Literal(table), mt.restriction)
+    result = []
+    for facet_i in params.entity_ids:
+        n = params.fiat_cell.compute_scaled_outward_normal(params.integration_dim, facet_i)
+        result.append(n)
+    return params.select_facet(gem.Literal(result), mt.restriction)
 
 
 @translate.register(CellEdgeVectors)
 def translate_cell_edge_vectors(terminal, mt, params):
     from FIAT.reference_element import TensorProductCell as fiat_TensorProductCell
-    fiat_cell = as_fiat_cell(terminal.ufl_domain().ufl_cell())
+    fiat_cell = params.fiat_cell
     if isinstance(fiat_cell, fiat_TensorProductCell):
         raise NotImplementedError("CellEdgeVectors not implemented on TensorProductElements yet")
 

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -31,7 +31,7 @@ def translate(terminal, mt, params):
 
 @translate.register(CellOrientation)
 def translate_cell_orientation(terminal, mt, params):
-    return params.kernel_interface.cell_orientation(mt.restriction)
+    return params.cell_orientation(mt.restriction)
 
 
 @translate.register(ReferenceCellVolume)

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -73,7 +73,7 @@ def translate_cell_facet_jacobian(terminal, mt, params):
 @translate.register(ReferenceNormal)
 def translate_reference_normal(terminal, mt, params):
     def callback(facet_i):
-        n = params.fiat_cell.compute_scaled_outward_normal(params.integration_dim, facet_i)
+        n = params.fiat_cell.compute_reference_normal(params.integration_dim, facet_i)
         return gem.Literal(n)
     return params.entity_selector(callback, mt.restriction)
 

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -3,7 +3,7 @@ expressions."""
 
 from __future__ import absolute_import
 
-from numpy import array, nan, vstack
+from numpy import array, vstack
 from singledispatch import singledispatch
 import sympy
 
@@ -30,14 +30,7 @@ def translate(terminal, mt, params):
 
 @translate.register(CellOrientation)
 def translate_cell_orientation(terminal, mt, params):
-    cell_orientations = params.cell_orientations
-    f = {None: 0, '+': 0, '-': 1}[mt.restriction]
-    co_int = gem.Indexed(cell_orientations, (f, 0))
-    return gem.Conditional(gem.Comparison("==", co_int, gem.Literal(1)),
-                           gem.Literal(-1),
-                           gem.Conditional(gem.Comparison("==", co_int, gem.Zero()),
-                                           gem.Literal(1),
-                                           gem.Literal(nan)))
+    return params.kernel_interface.cell_orientation(mt.restriction)
 
 
 @translate.register(ReferenceCellVolume)
@@ -100,6 +93,6 @@ def translate_cell_coordinate(terminal, mt, params):
 
 @translate.register(FacetCoordinate)
 def translate_facet_coordinate(terminal, mt, params):
-    assert params.integral_type != 'cell'
+    assert params.integration_dim != params.fiat_cell.get_dimension()
     points = params.points
     return gem.partial_indexed(gem.Literal(points), (params.point_index,))

--- a/tsfc/kernel_interface.py
+++ b/tsfc/kernel_interface.py
@@ -68,6 +68,7 @@ class KernelBuilderBase(object):
             return gem.partial_indexed(kernel_arg, {None: (), '+': (0,), '-': (1,)}[restriction])
 
     def cell_orientation(self, restriction):
+        """Cell orientation as a GEM expression."""
         f = {None: 0, '+': 0, '-': 1}[restriction]
         co_int = gem.Indexed(self._cell_orientations, (f, 0))
         return gem.Conditional(gem.Comparison("==", co_int, gem.Literal(1)),
@@ -160,6 +161,7 @@ class KernelBuilder(KernelBuilderBase):
             self._facet_number = {'+': 1, '-': 0}
 
     def facet_number(self, restriction):
+        """Facet number as a GEM index."""
         return self._facet_number[restriction]
 
     def set_arguments(self, arguments, indices):

--- a/tsfc/kernel_interface.py
+++ b/tsfc/kernel_interface.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from abc import ABCMeta, abstractmethod
-
 import numpy
 
 import coffee.base as coffee
@@ -12,25 +10,6 @@ from gem.node import traversal
 from tsfc.fiatinterface import create_element
 from tsfc.mixedelement import MixedElement
 from tsfc.coffee import SCALAR_TYPE
-
-
-class KernelInterface(object):
-    """Abstract class for interfacing kernel arguments during the
-    translation of UFL expressions."""
-
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def coefficient(self, ufl_coefficient, restriction):
-        pass
-
-    @abstractmethod
-    def cell_orientation(self, restriction):
-        pass
-
-    @abstractmethod
-    def facet_number(self, restriction):
-        pass
 
 
 class Kernel(object):
@@ -56,7 +35,7 @@ class Kernel(object):
         super(Kernel, self).__init__()
 
 
-class KernelBuilderBase(KernelInterface):
+class KernelBuilderBase(object):
     """Helper class for building local assembly kernels."""
 
     def __init__(self, integral_type):

--- a/tsfc/kernel_interface.py
+++ b/tsfc/kernel_interface.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from abc import ABCMeta, abstractmethod
+
 import numpy
 
 import coffee.base as coffee
@@ -10,6 +12,25 @@ from gem.node import traversal
 from tsfc.fiatinterface import create_element
 from tsfc.mixedelement import MixedElement
 from tsfc.coffee import SCALAR_TYPE
+
+
+class KernelInterface(object):
+    """Abstract class for interfacing kernel arguments during the
+    translation of UFL expressions."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def coefficient(self, ufl_coefficient, restriction):
+        pass
+
+    @abstractmethod
+    def cell_orientation(self, restriction):
+        pass
+
+    @abstractmethod
+    def facet_number(self, restriction):
+        pass
 
 
 class Kernel(object):
@@ -35,21 +56,61 @@ class Kernel(object):
         super(Kernel, self).__init__()
 
 
-class KernelBuilderBase(object):
+class KernelBuilderBase(KernelInterface):
     """Helper class for building local assembly kernels."""
 
-    def __init__(self, interior_facet=False):
+    def __init__(self, integral_type):
         """Initialise a kernel builder.
 
         :arg interior_facet: kernel accesses two cells
         """
-        assert isinstance(interior_facet, bool)
-        self.interior_facet = interior_facet
+        self.interior_facet = integral_type.startswith("interior_facet")
 
         self.prepare = []
         self.finalise = []
 
+        # Coefficients
         self.coefficient_map = {}
+
+        # Cell orientation
+        if integral_type.startswith("interior_facet"):
+            self._cell_orientations = gem.Variable("cell_orientations", (2, 1))
+        else:
+            self._cell_orientations = gem.Variable("cell_orientations", (1, 1))
+
+        # Facet number
+        if integral_type in ['exterior_facet', 'exterior_facet_vert']:
+            facet = gem.Variable('facet', (1,))
+            self._facet_number = {None: gem.VariableIndex(gem.Indexed(facet, (0,)))}
+        elif integral_type in ['interior_facet', 'interior_facet_vert']:
+            facet = gem.Variable('facet', (2,))
+            self._facet_number = {
+                '+': gem.VariableIndex(gem.Indexed(facet, (0,))),
+                '-': gem.VariableIndex(gem.Indexed(facet, (1,)))
+            }
+        elif integral_type == 'interior_facet_horiz':
+            self._facet_number = {'+': 1, '-': 0}
+
+    def coefficient(self, ufl_coefficient, restriction):
+        """A function that maps :class:`ufl.Coefficient`s to GEM
+        expressions."""
+        kernel_arg = self.coefficient_map[ufl_coefficient]
+        if ufl_coefficient.ufl_element().family() == 'Real':
+            return kernel_arg
+        else:
+            return gem.partial_indexed(kernel_arg, {None: (), '+': (0,), '-': (1,)}[restriction])
+
+    def cell_orientation(self, restriction):
+        f = {None: 0, '+': 0, '-': 1}[restriction]
+        co_int = gem.Indexed(self._cell_orientations, (f, 0))
+        return gem.Conditional(gem.Comparison("==", co_int, gem.Literal(1)),
+                               gem.Literal(-1),
+                               gem.Conditional(gem.Comparison("==", co_int, gem.Zero()),
+                                               gem.Literal(1),
+                                               gem.Literal(numpy.nan)))
+
+    def facet_number(self, restriction):
+        return self._facet_number[restriction]
 
     def apply_glue(self, prepare=None, finalise=None):
         """Append glue code for operations that are not handled in the
@@ -78,12 +139,6 @@ class KernelBuilderBase(object):
         body_ = coffee.Block(self.prepare + body.children + self.finalise)
         return coffee.FunDecl("void", name, args, body_, pred=["static", "inline"])
 
-    @property
-    def coefficient_mapper(self):
-        """A function that maps :class:`ufl.Coefficient`s to GEM
-        expressions."""
-        return lambda coefficient: self.coefficient_map[coefficient]
-
     def arguments(self, arguments, indices):
         """Prepare arguments. Adds glue code for the arguments.
 
@@ -97,7 +152,7 @@ class KernelBuilderBase(object):
         self.apply_glue(prepare, finalise)
         return funarg, expressions
 
-    def coefficient(self, coefficient, name, mode=None):
+    def _coefficient(self, coefficient, name, mode=None):
         """Prepare a coefficient. Adds glue code for the coefficient
         and adds the coefficient to the coefficient map.
 
@@ -119,7 +174,7 @@ class KernelBuilder(KernelBuilderBase):
 
     def __init__(self, integral_type, subdomain_id):
         """Initialise a kernel builder."""
-        super(KernelBuilder, self).__init__(integral_type.startswith("interior_facet"))
+        super(KernelBuilder, self).__init__(integral_type)
 
         self.kernel = Kernel(integral_type=integral_type, subdomain_id=subdomain_id)
         self.local_tensor = None
@@ -144,7 +199,7 @@ class KernelBuilder(KernelBuilderBase):
         :arg name: coordinate coefficient name
         :arg mode: see :func:`prepare_coefficient`
         """
-        self.coordinates_arg = self.coefficient(coefficient, name, mode)
+        self.coordinates_arg = self._coefficient(coefficient, name, mode)
 
     def set_coefficients(self, integral_data, form_data):
         """Prepare the coefficients of the form.
@@ -174,7 +229,7 @@ class KernelBuilder(KernelBuilderBase):
                 coefficient_numbers.append(form_data.original_coefficient_positions[i])
         for i, coefficient in enumerate(coefficients):
             self.coefficient_args.append(
-                self.coefficient(coefficient, "w_%d" % i))
+                self._coefficient(coefficient, "w_%d" % i))
         self.kernel.coefficient_numbers = tuple(coefficient_numbers)
 
     def require_cell_orientations(self):


### PR DESCRIPTION
This change represents TSFC/FIAT refactoring related to reference geometry. Furthermore, dispatching on the integral type is now limited to the kernel interface and `lower_integral_type` in the driver.

We also retire a few superseded solutions:
 * "`ufc_geometry.h`" (in `tsfc/geometric.py`)
 * The `FacetManager`.

Depends on [FIAT pull request #24](https://bitbucket.org/fenics-project/fiat/pull-requests/24).

Must be merged at the same time with firedrakeproject/firedrake#855.