### PR TITLE
Flexible indexing

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -479,6 +479,10 @@ class ComponentTensor(Node):
     def __new__(cls, expression, multiindex):
         assert not expression.shape
 
+        # Empty multiindex
+        if not multiindex:
+            return expression
+
         # Collect shape
         shape = tuple(index.extent for index in multiindex)
         assert all(shape)
@@ -613,7 +617,4 @@ def reshape(variable, *shapes):
             indices.append(i)
         dim2idxs.append((0, tuple(idxs)))
     expr = FlexiblyIndexed(variable, tuple(dim2idxs))
-    if indices:
-        return ComponentTensor(expr, tuple(indices))
-    else:
-        return expr
+    return ComponentTensor(expr, tuple(indices))

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -29,8 +29,8 @@ __all__ = ['Node', 'Identity', 'Literal', 'Zero', 'Variable', 'Sum',
            'Product', 'Division', 'Power', 'MathFunction', 'MinValue',
            'MaxValue', 'Comparison', 'LogicalNot', 'LogicalAnd',
            'LogicalOr', 'Conditional', 'Index', 'VariableIndex',
-           'Indexed', 'ComponentTensor', 'IndexSum', 'ListTensor',
-           'partial_indexed', 'reshape']
+           'Indexed', 'FlexiblyIndexed', 'ComponentTensor',
+           'IndexSum', 'ListTensor', 'partial_indexed', 'reshape']
 
 
 class NodeMeta(type):

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -438,10 +438,27 @@ class Indexed(Scalar):
 
 
 class FlexiblyIndexed(Scalar):
+    """Flexible indexing of :py:class:`Variable`s to implement views and
+    reshapes (splitting dimensions only)."""
+
     __slots__ = ('children', 'dim2idxs')
     __back__ = ('dim2idxs',)
 
     def __init__(self, variable, dim2idxs):
+        """Construct a flexibly indexed node.
+
+        :arg variable: a :py:class:`Variable`
+        :arg dim2idxs: describes the mapping of indices
+
+        For example, if ``variable`` is rank two, and ``dim2idxs`` is
+
+            ((1, ((i, 2), (j, 3), (k, 4))), (0, ()))
+
+        then this corresponds to the indexing:
+
+            variable[1 + i*12 + j*4 + k][0]
+
+        """
         assert isinstance(variable, Variable)
         assert len(variable.shape) == len(dim2idxs)
 
@@ -606,6 +623,11 @@ def partial_indexed(tensor, indices):
 
 
 def reshape(variable, *shapes):
+    """Reshape a variable (splitting indices only).
+
+    :arg variable: a :py:class:`Variable`
+    :arg shapes: one shape tuple for each dimension of the variable.
+    """
     dim2idxs = []
     indices = []
     for shape in shapes:

--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -56,8 +56,7 @@ def compile_gem(return_variables, expressions, prefix_ordering, remove_zeros=Fal
     # Collect indices in a deterministic order
     indices = []
     for node in traversal(expressions):
-        if isinstance(node, gem.Indexed):
-            indices.extend(node.multiindex)
+        indices.extend(node.free_indices)
     # The next two lines remove duplicate elements from the list, but
     # preserve the ordering, i.e. all elements will appear only once,
     # in the order of their first occurance in the original list.

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import
 from singledispatch import singledispatch
 
 from gem.node import Memoizer, MemoizerArg, reuse_if_untouched, reuse_if_untouched_arg
-from gem.gem import Node, Zero, Sum, Indexed, IndexSum, ComponentTensor
+from gem.gem import (Node, Terminal, Zero, Sum, Indexed, IndexSum,
+                     ComponentTensor, FlexiblyIndexed)
 
 
 @singledispatch
@@ -25,8 +26,8 @@ def replace_indices(node, self, subst):
 replace_indices.register(Node)(reuse_if_untouched_arg)
 
 
-@replace_indices.register(Indexed)  # noqa
-def _(node, self, subst):
+@replace_indices.register(Indexed)
+def replace_indices_indexed(node, self, subst):
     child, = node.children
     substitute = dict(subst)
     multiindex = tuple(substitute.get(i, i) for i in node.multiindex)
@@ -42,6 +43,24 @@ def _(node, self, subst):
             return node
         else:
             return Indexed(new_child, multiindex)
+
+
+@replace_indices.register(FlexiblyIndexed)
+def replace_indices_flexiblyindexed(node, self, subst):
+    child, = node.children
+    assert isinstance(child, Terminal)
+    assert not child.free_indices
+
+    substitute = dict(subst)
+    dim2idxs = tuple(
+        (offset, tuple((substitute.get(i, i), s) for i, s in idxs))
+        for offset, idxs in node.dim2idxs
+    )
+
+    if dim2idxs == node.dim2idxs:
+        return node
+    else:
+        return FlexiblyIndexed(child, dim2idxs)
 
 
 def filtered_replace_indices(node, self, subst):

--- a/gem/scheduling.py
+++ b/gem/scheduling.py
@@ -117,7 +117,7 @@ def handle(ops, push, decref, node):
             ops.append(impero.Evaluate(node))
     elif isinstance(node, gem.Zero):  # should rarely happen
         assert not node.shape
-    elif isinstance(node, gem.Indexed):
+    elif isinstance(node, (gem.Indexed, gem.FlexiblyIndexed)):
         # Indexing always inlined
         decref(node.children[0])
     elif isinstance(node, gem.IndexSum):

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -317,6 +317,13 @@ def _expression_indexed(expr, parameters):
 
 
 def cumulative_strides(strides):
+    """Calculate cumulative strides from per-dimension capacities.
+
+    For example:
+
+        [2, 3, 4] ==> [12, 4, 1]
+
+    """
     temp = numpy.flipud(numpy.cumprod(numpy.flipud(list(strides)[1:])))
     return list(temp) + [1]
 

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -348,5 +348,9 @@ def _expression_flexiblyindexed(expr, parameters):
         else:
             raise NotImplementedError("General case not implemented yet")
 
-    return coffee.Symbol(expression(expr.children[0], parameters),
+    variable = expression(expr.children[0], parameters)
+    assert isinstance(variable, coffee.Symbol)
+    assert not variable.rank
+    assert not variable.offset
+    return coffee.Symbol(variable.symbol,
                          rank=tuple(rank), offset=tuple(offset))

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -16,6 +16,7 @@ import coffee.base as coffee
 from gem import gem, impero as imp
 
 from tsfc.constants import SCALAR_TYPE, PRECISION
+from tsfc.logging import logger
 
 
 class Bunch(object):
@@ -362,6 +363,16 @@ def _expression_flexiblyindexed(expr, parameters):
             rank.append(parameters.index_names[i])
             offset.append((s, off))
         else:
-            raise NotImplementedError("COFFEE may break in this case.")
+            # Warn that this might break COFFEE
+            logger.warning("Multiple free indices in FlexiblyIndexed: might break COFFEE.")
+            index_expr = reduce(
+                coffee.Sum,
+                [coffee.Prod(coffee.Symbol(parameters.index_names[i]),
+                             coffee.Symbol(str(s)))
+                 for i, s in iss],
+                coffee.Symbol(str(off))
+            )
+            rank.append(index_expr)
+            offset.append((1, 0))
 
     return coffee.Symbol(var.symbol, rank=tuple(rank), offset=tuple(offset))


### PR DESCRIPTION
This change introduces a new indexed node type which can code generate things like `w[12 + 3*i + j]`. This indexed type can only be applied to terminal variables, and can implement reshapes (splitting dimensions only, no flattening) and views on tensors.

- This eliminates the need for the C hacks TSFC still uses for reshapes in `kernel_interface.py`.
- This eliminates the need for C syntax features that aren't supported by COFFEE (e.g. `const double w[restrict 10]` not supported by COFFEE, but `const double *restrict w` works).
- Improves compatibility with C++. (Though not compiling with C++ is a feature.)
- @dham: helps with `ufl.TensorElement`s on the FInAT branch.
- @blechta: helps avoiding [this hack](https://bitbucket.org/fenics-project/ffc/commits/2053f4592414b9bf5ee461f58701a1f200d621c1?at=master).