### PR TITLE
Fix index ordering

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -515,7 +515,7 @@ class ComponentTensor(Node):
 
         # Collect free indices
         assert set(multiindex) <= set(expression.free_indices)
-        self.free_indices = tuple(set(expression.free_indices) - set(multiindex))
+        self.free_indices = tuple(unique(list(set(expression.free_indices) - set(multiindex))))
 
         return self
 
@@ -540,7 +540,7 @@ class IndexSum(Scalar):
 
         # Collect shape and free indices
         assert index in summand.free_indices
-        self.free_indices = tuple(set(summand.free_indices) - {index})
+        self.free_indices = tuple(unique(list(set(summand.free_indices) - {index})))
 
         return self
 

--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -56,7 +56,12 @@ def compile_gem(return_variables, expressions, prefix_ordering, remove_zeros=Fal
     # Collect indices in a deterministic order
     indices = []
     for node in traversal(expressions):
-        indices.extend(node.free_indices)
+        if isinstance(node, gem.Indexed):
+            indices.extend(node.multiindex)
+        elif isinstance(node, gem.FlexiblyIndexed):
+            for offset, idxs in node.dim2idxs:
+                for index, stride in idxs:
+                    indices.append(index)
     # The next two lines remove duplicate elements from the list, but
     # preserve the ordering, i.e. all elements will appear only once,
     # in the order of their first occurance in the original list.


### PR DESCRIPTION
Fixes firedrakeproject/firedrake#877, and makes comparison of free indices (e.g. `x.free_indices == y.free_indices`) more robust.