### PR TITLE
Make GEM and TSFC mostly Python 3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 notifications:
   slack:
     secure: ZaeRnZLbnqMqFoH10X6U9ylAM4f9Up3ebgA097FVy71VD8hjMiw3lYZb7p/WxxsaQAplOykLQ8PUeuV7rOhotzT23xYijh3TpDrmxs+TnZ6HhHnILvV85YNfLyrvniPb6kHQHVcMTDPvIVqR9MP6gZqxZlnpqUttzYgr2rCv0vl98XE/TeY+IRUldsGEdZ84WTrWsNCb/LqCyM3+FJCHaXRZcmokHJsdStZNWpC4S9MfiDzd9DzH4pg4PT4xKLIRCtguhxnc/or56LYCnTV4PRRk4rdVaHOHRoN/0EGKOG9eWTInhDY33me7cCEAtqGsngBzpehQXDfd7YI6lnWriGpYRk+BmZaRrcuA40QEQa5z0WoHA/m7ev+3S6PGniI+ZZg2OuAw2gUgRIHfqwQ/oVREvVzR0HM9yia5JkyH9y6HtbCB9GBpt8mB+kIWQ8BIhk4sdHnKbUuEumjr9msnLQwqpI4jLoN0Ap+ZNnwoK8Lzjf/qGlcSsmkCQ2H3aI0s+q7mqHg9ZqDn0cph8qAkdCpnedHYk/itK/tPssN0O9jgOgqseVV8p2BWxR39LnHEE9F1ghTtHuW1wmBfokEa9JD6OraG/jG3Og9lqulnsNNk3bHf4digrVaHKQkprI0jeAfO0QcyuMGuAsvuY++CwzVC7SjRf02S555E9jFqnek=
+
 language: python
 python:
   - "2.7"
+  - "3.5"
 
 env:
   - NUMPY_VERSION="==1.9.0"
   - NUMPY_VERSION=">=1.10"
+
+matrix:
+  exclude:
+  - python: "3.5"
+  include:
+  - python: "3.5"
+    env: NUMPY_VERSION=">=1.10"
 
 before_install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 before_install:
   - pip install -r requirements.txt
   - pip install flake8
+  - pip install flake8-future-import
   - pip install --upgrade pytest
   - pip install --upgrade "numpy$NUMPY_VERSION"
 
@@ -19,5 +20,5 @@ install:
   - python setup.py install
 
 script:
-  - py.test tests
   - flake8 .
+  - py.test tests

--- a/gem/__init__.py
+++ b/gem/__init__.py
@@ -1,3 +1,3 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from gem.gem import *  # noqa

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -14,7 +14,7 @@ the Index objects in GEM, not on all the nodes that have those free
 indices.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from abc import ABCMeta
 from itertools import chain

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -15,12 +15,14 @@ indices.
 """
 
 from __future__ import absolute_import, print_function, division
+from six import with_metaclass
 
 from abc import ABCMeta
 from itertools import chain
+from operator import attrgetter
+
 import numpy
 from numpy import asarray, unique
-from operator import attrgetter
 
 from gem.node import Node as NodeBase
 
@@ -52,10 +54,8 @@ class NodeMeta(type):
         return obj
 
 
-class Node(NodeBase):
+class Node(with_metaclass(NodeMeta, NodeBase)):
     """Abstract GEM node class."""
-
-    __metaclass__ = NodeMeta
 
     __slots__ = ('free_indices')
 
@@ -339,10 +339,9 @@ class Conditional(Node):
         self.shape = then.shape
 
 
-class IndexBase(object):
+class IndexBase(with_metaclass(ABCMeta)):
     """Abstract base class for indices."""
-
-    __metaclass__ = ABCMeta
+    pass
 
 IndexBase.register(int)
 

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -378,6 +378,10 @@ class Index(IndexBase):
             return "Index(%r)" % self.count
         return "Index(%r)" % self.name
 
+    def __lt__(self, other):
+        # Allow sorting of free indices in Python 3
+        return id(self) < id(other)
+
 
 class VariableIndex(IndexBase):
     """An index that is constant during a single execution of the

--- a/gem/impero.py
+++ b/gem/impero.py
@@ -10,7 +10,7 @@ Trivia:
    (Command?) after clicking on them.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from abc import ABCMeta, abstractmethod
 

--- a/gem/impero.py
+++ b/gem/impero.py
@@ -11,6 +11,7 @@ Trivia:
 """
 
 from __future__ import absolute_import, print_function, division
+from six import with_metaclass
 
 from abc import ABCMeta, abstractmethod
 
@@ -23,10 +24,8 @@ class Node(NodeBase):
     __slots__ = ()
 
 
-class Terminal(Node):
+class Terminal(with_metaclass(ABCMeta, Node)):
     """Abstract class for terminal Impero nodes"""
-
-    __metaclass__ = ABCMeta
 
     __slots__ = ()
 

--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -6,7 +6,7 @@ What this module does is independent of whether we eventually generate
 C code or a COFFEE AST.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import collections
 import itertools

--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -7,6 +7,7 @@ C code or a COFFEE AST.
 """
 
 from __future__ import absolute_import, print_function, division
+from six.moves import zip
 
 import collections
 import itertools
@@ -75,7 +76,7 @@ def compile_gem(return_variables, expressions, prefix_ordering, remove_zeros=Fal
     get_indices = lambda expr: apply_ordering(expr.free_indices)
 
     # Build operation ordering
-    ops = scheduling.emit_operations(zip(return_variables, expressions), get_indices)
+    ops = scheduling.emit_operations(list(zip(return_variables, expressions)), get_indices)
 
     # Empty kernel
     if len(ops) == 0:
@@ -177,7 +178,7 @@ def make_loop_tree(ops, get_indices, level=0):
         else:
             statements.extend(op_group)
     # Remove no-op terminals from the tree
-    statements = filter(lambda s: not isinstance(s, imp.Noop), statements)
+    statements = [s for s in statements if not isinstance(s, imp.Noop)]
     return imp.Block(statements)
 
 

--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -58,11 +58,14 @@ def compile_gem(return_variables, expressions, prefix_ordering, remove_zeros=Fal
     indices = []
     for node in traversal(expressions):
         if isinstance(node, gem.Indexed):
-            indices.extend(node.multiindex)
+            for index in node.multiindex:
+                if isinstance(index, gem.Index):
+                    indices.append(index)
         elif isinstance(node, gem.FlexiblyIndexed):
             for offset, idxs in node.dim2idxs:
                 for index, stride in idxs:
-                    indices.append(index)
+                    if isinstance(index, gem.Index):
+                        indices.append(index)
     # The next two lines remove duplicate elements from the list, but
     # preserve the ordering, i.e. all elements will appear only once,
     # in the order of their first occurance in the original list.

--- a/gem/interpreter.py
+++ b/gem/interpreter.py
@@ -2,6 +2,7 @@
 An interpreter for GEM trees.
 """
 from __future__ import absolute_import, print_function, division
+from six.moves import map
 
 import numpy
 import operator
@@ -302,4 +303,4 @@ def evaluate(expressions, bindings=None):
         exprs = (expressions, )
     mapper = node.Memoizer(_evaluate)
     mapper.bindings = bindings if bindings is not None else {}
-    return map(mapper, exprs)
+    return list(map(mapper, exprs))

--- a/gem/interpreter.py
+++ b/gem/interpreter.py
@@ -1,7 +1,7 @@
 """
 An interpreter for GEM trees.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import numpy
 import operator

--- a/gem/node.py
+++ b/gem/node.py
@@ -2,6 +2,7 @@
 expression DAG languages."""
 
 from __future__ import absolute_import, print_function, division
+from six.moves import map
 
 import collections
 
@@ -201,7 +202,7 @@ class MemoizerArg(object):
 
 def reuse_if_untouched(node, self):
     """Reuse if untouched recipe"""
-    new_children = map(self, node.children)
+    new_children = list(map(self, node.children))
     if all(nc == c for nc, c in zip(new_children, node.children)):
         return node
     else:

--- a/gem/node.py
+++ b/gem/node.py
@@ -1,7 +1,7 @@
 """Generic abstract node class and utility functions for creating
 expression DAG languages."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import collections
 

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -1,8 +1,9 @@
 """A set of routines implementing various transformations on GEM
 expressions."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
+from functools import reduce
 from singledispatch import singledispatch
 
 from gem.node import Memoizer, MemoizerArg, reuse_if_untouched, reuse_if_untouched_arg

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -2,6 +2,7 @@
 expressions."""
 
 from __future__ import absolute_import, print_function, division
+from six.moves import map
 
 from functools import reduce
 from singledispatch import singledispatch
@@ -112,4 +113,4 @@ def unroll_indexsum(expressions, max_extent):
     """
     mapper = Memoizer(_unroll_indexsum)
     mapper.max_extent = max_extent
-    return map(mapper, expressions)
+    return list(map(mapper, expressions))

--- a/gem/scheduling.py
+++ b/gem/scheduling.py
@@ -1,7 +1,7 @@
 """Schedules operations to evaluate a multi-root expression DAG,
 forming an ordered list of Impero terminals."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import collections
 import functools

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,2 +1,3 @@
 numpy
 singledispatch
+six

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [flake8]
-ignore = E501,E226,E731
-exclude = .git,__pycache__
+ignore =
+    E501,E226,E731,
+    FI14,FI54,
+    FI50,FI51,FI53
+exclude = .git,__pycache__,build,dist
+min-version = 2.7

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 from distutils.core import setup
 
 version = "0.0.1"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function, division
+
 import pytest
 
 from gem import impero_utils

--- a/tests/test_create_element.py
+++ b/tests/test_create_element.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function, division
 from tsfc import fiatinterface as f
 import pytest
 import ufl

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function, division
 import ufl
 from tsfc import compile_form
 import pytest

--- a/tsfc/__init__.py
+++ b/tsfc/__init__.py
@@ -1,3 +1,3 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from tsfc.driver import compile_form  # noqa

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -2,9 +2,10 @@
 
 This is the final stage of code generation in TSFC."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from collections import defaultdict
+from functools import reduce
 from math import isnan
 import itertools
 

--- a/tsfc/compat.py
+++ b/tsfc/compat.py
@@ -1,6 +1,7 @@
 """
 Backwards compatibility for some functionality.
 """
+from __future__ import absolute_import, print_function, division
 import numpy
 from distutils.version import StrictVersion
 

--- a/tsfc/constants.py
+++ b/tsfc/constants.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import numpy
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -1,7 +1,8 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import collections
 import time
+from functools import reduce
 
 from ufl.classes import Form
 from ufl.log import GREEN

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, division
+from six.moves import range
 
 import collections
 import time
@@ -278,6 +279,6 @@ def lower_integral_type(fiat_cell, integral_type):
     elif integral_type == 'exterior_facet_top':
         entity_ids = [1]
     else:
-        entity_ids = range(len(fiat_cell.get_topology()[integration_dim]))
+        entity_ids = list(range(len(fiat_cell.get_topology()[integration_dim])))
 
     return integration_dim, entity_ids

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, division
+from six.moves import map, range
 
 import collections
 import itertools
@@ -89,7 +90,7 @@ class TabulationManager(object):
                             each integration entity, i.e. an iterable
                             of arrays of points.
         """
-        self.tabulators = map(make_tabulator, entity_points)
+        self.tabulators = list(map(make_tabulator, entity_points))
         self.tables = {}
 
     def tabulate(self, ufl_element, max_deriv):
@@ -188,7 +189,7 @@ class Parameters(object):
         result = []
         for entity_id in self.entity_ids:
             t = self.fiat_cell.get_entity_transform(self.integration_dim, entity_id)
-            result.append(numpy.asarray(map(t, self.points)))
+            result.append(numpy.asarray(list(map(t, self.points))))
         return result
 
     def _selector(self, callback, opts, restriction):
@@ -197,7 +198,7 @@ class Parameters(object):
         if len(opts) == 1:
             return callback(opts[0])
         else:
-            results = gem.ListTensor(map(callback, opts))
+            results = gem.ListTensor(list(map(callback, opts)))
             f = self.facet_number(restriction)
             return gem.partial_indexed(results, (f,))
 
@@ -226,7 +227,7 @@ class Parameters(object):
         :arg restriction: Restriction of the modified terminal, used
                           for entity selection.
         """
-        return self._selector(callback, range(len(self.entity_ids)), restriction)
+        return self._selector(callback, list(range(len(self.entity_ids))), restriction)
 
     argument_indices = ()
 
@@ -272,7 +273,7 @@ def iterate_shape(mt, callback):
         return tuple((numpy.asarray(ordered_deriv) == d).sum() for d in range(dim))
 
     ordered_derivs = itertools.product(range(dim), repeat=mt.local_derivatives)
-    flat_derivs = map(flat_index, ordered_derivs)
+    flat_derivs = list(map(flat_index, ordered_derivs))
 
     result = []
     for c in range(ufl_element.reference_value_size()):

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -1,7 +1,8 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import collections
 import itertools
+from functools import reduce
 
 import numpy
 from singledispatch import singledispatch

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, division
+from six import iteritems
 from six.moves import map, range
 
 import collections
@@ -49,7 +50,7 @@ def _tabulate(ufl_element, order, points):
     phi = element.space_dimension()
     C = ufl_element.reference_value_size()
     q = len(points)
-    for D, fiat_table in element.tabulate(order, points).iteritems():
+    for D, fiat_table in iteritems(element.tabulate(order, points)):
         reordered_table = fiat_table.reshape(phi, C, q).transpose(1, 2, 0)  # (C, q, phi)
         for c, table in enumerate(reordered_table):
             yield c, D, table
@@ -105,7 +106,7 @@ class TabulationManager(object):
             for c, D, table in tabulator(ufl_element, max_deriv):
                 store[(ufl_element, c, D)].append(table)
 
-        for key, tables in store.iteritems():
+        for key, tables in iteritems(store):
             table = numpy.array(tables)
             if len(table.shape) == 2:
                 # Cellwise constant; must not depend on the facet

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -21,8 +21,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with FFC. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function, division
 
 from singledispatch import singledispatch
 from functools import partial

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -1,7 +1,7 @@
 """Functions to translate UFL reference geometric quantities into GEM
 expressions."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from numpy import allclose, vstack
 from singledispatch import singledispatch

--- a/tsfc/kernel_interface/__init__.py
+++ b/tsfc/kernel_interface/__init__.py
@@ -1,1 +1,1 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import numpy
 

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import numpy
 from itertools import product

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import numpy
 from itertools import product
@@ -201,7 +201,7 @@ def prepare_coordinates(coefficient, name, interior_facet=False):
     shape = (fiat_element.space_dimension(),)
     gdim = coefficient.ufl_element().cell().geometric_dimension()
     assert len(shape) == 1 and shape[0] % gdim == 0
-    num_nodes = shape[0] / gdim
+    num_nodes = shape[0] // gdim
 
     # Translate coords from XYZXYZXYZXYZ into XXXXYYYYZZZZ
     # NOTE: See dolfin/mesh/Cell.h:get_coordinate_dofs for ordering scheme

--- a/tsfc/logging.py
+++ b/tsfc/logging.py
@@ -1,6 +1,6 @@
 """Logging for TSFC."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import logging
 

--- a/tsfc/mixedelement.py
+++ b/tsfc/mixedelement.py
@@ -21,8 +21,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with FFC. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function, division
 
 import numpy
 

--- a/tsfc/mixedelement.py
+++ b/tsfc/mixedelement.py
@@ -22,6 +22,7 @@
 # along with FFC. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import, print_function, division
+from six.moves import map
 
 import numpy
 
@@ -67,8 +68,8 @@ class MixedElement(object):
         for i, d in enumerate(dicts):
             for dim, dofs in d.items():
                 for ent, off in dofs.items():
-                    ret[dim][ent] += map(partial(add, offsets[i]),
-                                         off)
+                    ret[dim][ent] += list(map(partial(add, offsets[i]),
+                                              off))
         self._entity_dofs = ret
         return self._entity_dofs
 

--- a/tsfc/modified_terminals.py
+++ b/tsfc/modified_terminals.py
@@ -20,7 +20,7 @@
 
 """Definitions of 'modified terminals', a core concept in uflacs."""
 
-from __future__ import print_function  # used in some debugging
+from __future__ import absolute_import, print_function, division
 
 from ufl.classes import (ReferenceValue, ReferenceGrad,
                          NegativeRestricted, PositiveRestricted,

--- a/tsfc/ufl2gem.py
+++ b/tsfc/ufl2gem.py
@@ -1,6 +1,6 @@
 """Translation of UFL tensor-algebra into GEM tensor-algebra."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import collections
 import ufl

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -1,6 +1,6 @@
 """Utilities for preprocessing UFL objects."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import numpy
 from singledispatch import singledispatch


### PR DESCRIPTION
This will move the code base towards a common subset of Python 2.7 and Python 3. Considering the dependencies, UFL and FIAT ought to work with Python 3, but COFFEE is Python 2 only. This depends on coneoproject/COFFEE#94 which fixes just enough of COFFEE to make the TSFC test suite pass with Python 3.5.