### PR TITLE
Recognize numpy.integer as gem.IndexBase

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -344,6 +344,7 @@ class IndexBase(with_metaclass(ABCMeta)):
     pass
 
 IndexBase.register(int)
+IndexBase.register(numpy.integer)
 
 
 class Index(IndexBase):


### PR DESCRIPTION
Allows to run FFC regression tests with Py3.