### PR TITLE
Fix epsilon numerical tolerance

### DIFF
--- a/tsfc/constants.py
+++ b/tsfc/constants.py
@@ -7,8 +7,6 @@ NUMPY_TYPE = numpy.dtype("double")
 
 _PRECISION = numpy.finfo(NUMPY_TYPE).precision
 
-_EPSILON = eval("1e-%d" % (_PRECISION - 1))
-
 SCALAR_TYPE = {numpy.dtype("double"): "double",
                numpy.dtype("float32"): "float"}[NUMPY_TYPE]
 
@@ -25,9 +23,6 @@ PARAMETERS = {
 
     # Precision of float printing (number of digits)
     "precision": _PRECISION,
-
-    # Threshold for rounding FE tables to 0, +/- 1/2, +/- 1
-    "epsilon": _EPSILON,
 }
 
 

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -386,8 +386,11 @@ def compile_ufl(expression, parameters, interior_facet=False, **kwargs):
             ufl_element = mt.terminal.ufl_element()
             max_derivs[ufl_element] = max(mt.local_derivatives, max_derivs[ufl_element])
 
+    # Rounding tolerance mimicking FFC
+    epsilon = 10.0 * eval("1e-%d" % parameters["precision"])
+
     # Collect tabulations for all components and derivatives
-    tabulation_manager = TabulationManager(params.entity_points, parameters["epsilon"])
+    tabulation_manager = TabulationManager(params.entity_points, epsilon)
     for ufl_element, max_deriv in max_derivs.items():
         if ufl_element.family() != 'Real':
             tabulation_manager.tabulate(ufl_element, max_deriv)


### PR DESCRIPTION
Turns out that the `format["epsilon"]` in FFC does not come from `parameters["epsilon"]`, but is calculated from `parameters["precision"]`. This change reflects this discovery.

Related to the discussion in #64, but does not fix that issue.