### PR TITLE
Refactor CellVolume and FacetArea implementation

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -354,12 +354,11 @@ class Index(IndexBase):
 
     __slots__ = ('name', 'extent', 'count')
 
-    def __init__(self, name=None):
+    def __init__(self, name=None, extent=None):
         self.name = name
         Index._count += 1
         self.count = Index._count
-        # Initialise with indefinite extent
-        self.extent = None
+        self.extent = extent
 
     def set_extent(self, value):
         # Set extent, check for consistency
@@ -645,8 +644,7 @@ def reshape(variable, *shapes):
     for shape in shapes:
         idxs = []
         for e in shape:
-            i = Index()
-            i.set_extent(e)
+            i = Index(extent=e)
             idxs.append((i, e))
             indices.append(i)
         dim2idxs.append((0, tuple(idxs)))

--- a/gem/utils.py
+++ b/gem/utils.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import, print_function, division
+
+import collections
+
+
+# This is copied from PyOP2, and it is here to be available for both
+# FInAT and TSFC without depending on PyOP2.
+class cached_property(object):
+    """A read-only @property that is only evaluated once. The value is cached
+    on the object itself rather than the function or class; this should prevent
+    memory leakage."""
+    def __init__(self, fget, doc=None):
+        self.fget = fget
+        self.__doc__ = doc or fget.__doc__
+        self.__name__ = fget.__name__
+        self.__module__ = fget.__module__
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+        obj.__dict__[self.__name__] = result = self.fget(obj)
+        return result
+
+
+class OrderedSet(collections.MutableSet):
+    """A set that preserves ordering, useful for deterministic code
+    generation."""
+
+    def __init__(self, iterable=None):
+        self._list = list()
+        self._set = set()
+
+        if iterable is not None:
+            for item in iterable:
+                self.add(item)
+
+    def __contains__(self, item):
+        return item in self._set
+
+    def __iter__(self):
+        return iter(self._list)
+
+    def __len__(self):
+        return len(self._list)
+
+    def __repr__(self):
+        return "OrderedSet({0})".format(self._list)
+
+    def add(self, value):
+        if value not in self._set:
+            self._list.append(value)
+            self._set.add(value)
+
+    def discard(self, value):
+        # O(n) time complexity: do not use this!
+        if value in self._set:
+            self._list.remove(value)
+            self._set.discard(value)

--- a/gem/utils.py
+++ b/gem/utils.py
@@ -22,22 +22,6 @@ class cached_property(object):
         return result
 
 
-class unset_attribute(object):
-    """Decorator for listing and documenting instance attributes without
-    setting a default value."""
-
-    def __init__(self, f):
-        """Initialise this property.
-
-        :arg f: dummy method
-        """
-        self.__doc__ = f.__doc__
-        self.__name__ = f.__name__
-
-    def __get__(self, obj, cls):
-        raise AttributeError("'{0}' object has no attribute '{1}'".format(cls.__name__, self.__name__))
-
-
 class OrderedSet(collections.MutableSet):
     """A set that preserves ordering, useful for deterministic code
     generation."""

--- a/tsfc/__init__.py
+++ b/tsfc/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import, print_function, division
 
 from tsfc.driver import compile_form, compile_expression_at_points  # noqa: F401
+from tsfc.parameters import default_parameters  # noqa: F401

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -16,7 +16,7 @@ import coffee.base as coffee
 
 from gem import gem, impero as imp
 
-from tsfc.constants import SCALAR_TYPE
+from tsfc.parameters import SCALAR_TYPE
 from tsfc.logging import logger
 
 
@@ -24,12 +24,12 @@ class Bunch(object):
     pass
 
 
-def generate(impero_c, index_names, parameters, roots=(), argument_indices=()):
+def generate(impero_c, index_names, precision, roots=(), argument_indices=()):
     """Generates COFFEE code.
 
     :arg impero_c: ImperoC tuple with Impero AST and other data
     :arg index_names: pre-assigned index names
-    :arg parameters: TSFC parameters
+    :arg precision: floating-point precision for printing
     :arg roots: list of expression DAG roots for attaching
         #pragma coffee expression
     :arg argument_indices: argument indices for attaching
@@ -40,6 +40,7 @@ def generate(impero_c, index_names, parameters, roots=(), argument_indices=()):
     params = Bunch()
     params.declare = impero_c.declare
     params.indices = impero_c.indices
+    params.precision = precision
     params.roots = roots
     params.argument_indices = argument_indices
 
@@ -50,8 +51,6 @@ def generate(impero_c, index_names, parameters, roots=(), argument_indices=()):
     counter = itertools.count()
     params.index_names = defaultdict(lambda: "i_%d" % next(counter))
     params.index_names.update(index_names)
-
-    params.precision = parameters["precision"]
 
     return statement(impero_c.tree, params)
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -205,24 +205,16 @@ class CellVolumeKernelInterface(ProxyKernelInterface):
 def cellvolume_generator(domain, coordinate_coefficient, kernel_config):
     def cellvolume(restriction):
         from ufl import dx
-        form = 1 * dx(domain=domain)
-        fd = ufl_utils.compute_form_data(form)
-        itg_data, = fd.integral_data
-        integral, = itg_data.integrals
+        integrand, degree = one_times(dx(domain=domain))
+        integrand = ufl_utils.replace_coordinates(integrand, coordinate_coefficient)
 
-        integrand = ufl_utils.replace_coordinates(integral.integrand(),
-                                                  coordinate_coefficient)
-
-        # Check if the integral has a quad degree attached, otherwise use
-        # the estimated polynomial degree attached by compute_form_data
-        quadrature_degree = integral.metadata()["estimated_polynomial_degree"]
+        interface = CellVolumeKernelInterface(kernel_config["interface"], restriction)
         quadrature_index = gem.Index(name='q')
 
         config = {k: v for k, v in kernel_config.items()
                   if k in ["ufl_cell", "precision", "index_cache"]}
-        interface = CellVolumeKernelInterface(kernel_config["interface"], restriction)
         config.update(interface=interface,
-                      quadrature_degree=quadrature_degree,
+                      quadrature_degree=degree,
                       point_index=quadrature_index)
         expr, = fem.compile_ufl(integrand, **config)
         if quadrature_index in expr.free_indices:
@@ -235,27 +227,43 @@ def facetarea_generator(domain, coordinate_coefficient, kernel_config, integral_
     def facetarea():
         from ufl import Measure
         assert integral_type != 'cell'
-        form = 1 * Measure(integral_type, domain=domain)
-        fd = ufl_utils.compute_form_data(form)
-        itg_data, = fd.integral_data
-        integral, = itg_data.integrals
+        integrand, degree = one_times(Measure(integral_type, domain=domain))
+        integrand = ufl_utils.replace_coordinates(integrand, coordinate_coefficient)
 
-        integrand = ufl_utils.replace_coordinates(integral.integrand(),
-                                                  coordinate_coefficient)
-
-        # Check if the integral has a quad degree attached, otherwise use
-        # the estimated polynomial degree attached by compute_form_data
-        quadrature_degree = integral.metadata()["estimated_polynomial_degree"]
         quadrature_index = gem.Index(name='q')
 
         config = kernel_config.copy()
-        config.update(quadrature_degree=quadrature_degree,
-                      point_index=quadrature_index)
+        config.update(quadrature_degree=degree, point_index=quadrature_index)
         expr, = fem.compile_ufl(integrand, **config)
         if quadrature_index in expr.free_indices:
             expr = gem.IndexSum(expr, quadrature_index)
         return expr
     return facetarea
+
+
+def one_times(measure):
+    # Workaround for UFL issue #80:
+    # https://bitbucket.org/fenics-project/ufl/issues/80
+    from ufl import replace
+    from ufl.algorithms import estimate_total_polynomial_degree
+    from ufl.geometry import QuadratureWeight
+
+    form = 1 * measure
+    fd = ufl_utils.compute_form_data(form, do_estimate_degrees=False)
+    itg_data, = fd.integral_data
+    integral, = itg_data.integrals
+    integrand = integral.integrand()
+
+    # UFL considers QuadratureWeight a geometric quantity, and the
+    # general handler for geometric quantities estimates the degree of
+    # the coordinate element.  This would unnecessarily increase the
+    # estimated degree, so we drop QuadratureWeight instead.
+    expression = replace(integrand, {QuadratureWeight(itg_data.domain): 1})
+
+    # Now estimate degree for the preprocessed form
+    degree = estimate_total_polynomial_degree(expression)
+
+    return integrand, degree
 
 
 def compile_expression_at_points(expression, points, coordinates, parameters=None):
@@ -299,12 +307,13 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
 
     # Translate to GEM
     point_index = gem.Index(name='p')
-    ir, = fem.compile_ufl(expression,
-                          interface=builder,
-                          ufl_cell=coordinates.ufl_domain().ufl_cell(),
-                          precision=parameters["precision"],
-                          points=points,
-                          point_index=point_index)
+    config = dict(interface=builder,
+                  ufl_cell=coordinates.ufl_domain().ufl_cell(),
+                  precision=parameters["precision"],
+                  points=points,
+                  point_index=point_index)
+    config["cellvolume"] = cellvolume_generator(coordinates.ufl_domain(), coordinates, config)
+    ir, = fem.compile_ufl(expression, **config)
 
     # Deal with non-scalar expressions
     value_shape = ir.shape

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -113,6 +113,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
 
     kernel_cfg = dict(interface=builder,
                       ufl_cell=cell,
+                      precision=parameters["precision"],
                       integration_dim=integration_dim,
                       entity_ids=entity_ids,
                       argument_indices=argument_indices,
@@ -142,7 +143,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
             assert restriction is None
             kernel_interface = builder
         ir = fem.compile_ufl(integrand,
-                             parameters,
+                             precision=parameters["precision"],
                              interface=kernel_interface,
                              ufl_cell=cell,
                              quadrature_degree=quadrature_degree,
@@ -173,7 +174,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
         config = kernel_cfg.copy()
         config.update(quadrature_degree=quadrature_degree,
                       point_index=quadrature_index)
-        ir = fem.compile_ufl(integrand, parameters, **config)
+        ir = fem.compile_ufl(integrand, **config)
         if parameters["unroll_indexsum"]:
             ir = opt.unroll_indexsum(ir, max_extent=parameters["unroll_indexsum"])
         expr, = ir
@@ -212,7 +213,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
         quadrature_indices.append(quadrature_index)
         config = kernel_cfg.copy()
         config.update(quadrature_rule=quad_rule, point_index=quadrature_index)
-        ir = fem.compile_ufl(integrand, parameters, interior_facet=interior_facet, **config)
+        ir = fem.compile_ufl(integrand, interior_facet=interior_facet, **config)
         if parameters["unroll_indexsum"]:
             ir = opt.unroll_indexsum(ir, max_extent=parameters["unroll_indexsum"])
         irs.append([(gem.IndexSum(expr, quadrature_index)
@@ -290,9 +291,9 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
     # Translate to GEM
     point_index = gem.Index(name='p')
     ir, = fem.compile_ufl(expression,
-                          parameters,
                           interface=builder,
                           ufl_cell=coordinates.ufl_domain().ufl_cell(),
+                          precision=parameters["precision"],
                           points=points,
                           point_index=point_index)
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -15,10 +15,10 @@ import gem.optimise as opt
 import gem.impero_utils as impero_utils
 
 from tsfc import fem, ufl_utils
-from tsfc.coffee import generate as generate_coffee
-from tsfc.constants import SCALAR_TYPE, default_parameters
+from tsfc.coffee import SCALAR_TYPE, generate as generate_coffee
 from tsfc.fiatinterface import QuadratureRule, as_fiat_cell, create_quadrature
 from tsfc.logging import logger
+from tsfc.parameters import default_parameters
 
 from tsfc.kernel_interface import ProxyKernelInterface
 import tsfc.kernel_interface.firedrake as firedrake_interface
@@ -182,7 +182,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
         for i, quadrature_index in enumerate(quadrature_indices):
             index_names.append((quadrature_index, 'ip_%d' % i))
 
-    body = generate_coffee(impero_c, index_names, parameters, ir, argument_indices)
+    body = generate_coffee(impero_c, index_names, parameters["precision"], ir, argument_indices)
 
     kernel_name = "%s_%s_integral_%s" % (prefix, integral_type, integral_data.subdomain_id)
     return builder.construct_kernel(kernel_name, body)
@@ -309,7 +309,7 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
     return_arg = ast.Decl(SCALAR_TYPE, ast.Symbol('A', rank=return_shape))
     return_expr = gem.Indexed(return_var, return_indices)
     impero_c = impero_utils.compile_gem([return_expr], [ir], return_indices)
-    body = generate_coffee(impero_c, {point_index: 'p'}, parameters)
+    body = generate_coffee(impero_c, {point_index: 'p'}, parameters["precision"])
 
     # Handle cell orientations
     if builder.needs_cell_orientations([ir]):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -218,14 +218,13 @@ def cellvolume_generator(domain, coordinate_coefficient, kernel_config):
         quadrature_degree = integral.metadata()["estimated_polynomial_degree"]
         quadrature_index = gem.Index(name='q')
 
+        config = {k: v for k, v in kernel_config.items()
+                  if k in ["ufl_cell", "precision", "index_cache"]}
         interface = CellVolumeKernelInterface(kernel_config["interface"], restriction)
-        expr, = fem.compile_ufl(integrand,
-                                interface=interface,
-                                ufl_cell=kernel_config["ufl_cell"],
-                                quadrature_degree=quadrature_degree,
-                                precision=kernel_config["precision"],
-                                point_index=quadrature_index,
-                                index_cache=kernel_config["index_cache"])
+        config.update(interface=interface,
+                      quadrature_degree=quadrature_degree,
+                      point_index=quadrature_index)
+        expr, = fem.compile_ufl(integrand, **config)
         if quadrature_index in expr.free_indices:
             expr = gem.IndexSum(expr, quadrature_index)
         return expr

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -16,7 +16,7 @@ from ufl.classes import (Argument, Coefficient, CellVolume,
                          GeometricQuantity, QuadratureWeight)
 
 import gem
-from gem.utils import cached_property
+from gem.utils import cached_property, unset_attribute
 
 from tsfc.fiatinterface import create_element, create_quadrature, as_fiat_cell
 from tsfc.modified_terminals import analyse_modified_terminal
@@ -142,6 +142,10 @@ class Parameters(object):
             raise ValueError("unexpected keyword argument '{0}'".format(invalid_keywords.pop()))
         self.__dict__.update(kwargs)
 
+    @unset_attribute
+    def cell(self):
+        pass
+
     @cached_property
     def fiat_cell(self):
         return as_fiat_cell(self.cell)
@@ -151,6 +155,10 @@ class Parameters(object):
         return self.fiat_cell.get_dimension()
 
     entity_ids = [0]
+
+    @unset_attribute
+    def quadrature_degree(self):
+        pass
 
     @cached_property
     def quadrature_rule(self):
@@ -212,7 +220,31 @@ class Parameters(object):
         """
         return self._selector(callback, list(range(len(self.entity_ids))), restriction)
 
+    @unset_attribute
+    def point_index(self):
+        pass
+
     argument_indices = ()
+
+    @unset_attribute
+    def coefficient(self):
+        pass
+
+    @unset_attribute
+    def cell_orientation(self):
+        pass
+
+    @unset_attribute
+    def facet_number(self):
+        pass
+
+    @unset_attribute
+    def cellvolume(self):
+        pass
+
+    @unset_attribute
+    def facetarea(self):
+        pass
 
     @cached_property
     def index_cache(self):

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -120,7 +120,7 @@ class TabulationManager(object):
 
 
 class Parameters(ProxyKernelInterface):
-    keywords = ('cell',
+    keywords = ('ufl_cell',
                 'fiat_cell',
                 'integration_dim',
                 'entity_ids',
@@ -136,8 +136,8 @@ class Parameters(ProxyKernelInterface):
 
     def __init__(self, **kwargs):
         # Initialise superclass
-        ProxyKernelInterface.__init__(self, kwargs["kernel_interface"])
-        del kwargs["kernel_interface"]
+        ProxyKernelInterface.__init__(self, kwargs["interface"])
+        del kwargs["interface"]
 
         invalid_keywords = set(kwargs.keys()) - set(Parameters.keywords)
         if invalid_keywords:
@@ -145,12 +145,12 @@ class Parameters(ProxyKernelInterface):
         self.__dict__.update(kwargs)
 
     @unset_attribute
-    def cell(self):
+    def ufl_cell(self):
         pass
 
     @cached_property
     def fiat_cell(self):
-        return as_fiat_cell(self.cell)
+        return as_fiat_cell(self.ufl_cell)
 
     @cached_property
     def integration_dim(self):

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -18,13 +18,11 @@ from ufl.classes import (Argument, Coefficient, CellVolume,
 import gem
 from gem.utils import cached_property
 
-from tsfc.constants import _PRECISION as PRECISION
+from tsfc import compat, ufl2gem, geometric
 from tsfc.fiatinterface import create_element, create_quadrature, as_fiat_cell
 from tsfc.kernel_interface import ProxyKernelInterface
 from tsfc.modified_terminals import analyse_modified_terminal
-from tsfc import compat
-from tsfc import ufl2gem
-from tsfc import geometric
+from tsfc.parameters import PARAMETERS
 from tsfc.ufl_utils import (CollectModifiedTerminals,
                             ModifiedTerminalMixin, PickRestriction,
                             spanning_degree, simplify_abs)
@@ -167,7 +165,7 @@ class Context(ProxyKernelInterface):
     def weights(self):
         return self.quadrature_rule.get_weights()
 
-    precision = PRECISION
+    precision = PARAMETERS["precision"]
 
     @cached_property
     def epsilon(self):

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -16,6 +16,7 @@ from ufl.classes import (Argument, Coefficient, CellVolume,
                          GeometricQuantity, QuadratureWeight)
 
 import gem
+from gem.utils import cached_property
 
 from tsfc.fiatinterface import create_element, create_quadrature, as_fiat_cell
 from tsfc.modified_terminals import analyse_modified_terminal
@@ -115,24 +116,6 @@ class TabulationManager(object):
 
     def __getitem__(self, key):
         return self.tables[key]
-
-
-# FIXME: copy-paste from PyOP2
-class cached_property(object):
-    """A read-only @property that is only evaluated once. The value is cached
-    on the object itself rather than the function or class; this should prevent
-    memory leakage."""
-    def __init__(self, fget, doc=None):
-        self.fget = fget
-        self.__doc__ = doc or fget.__doc__
-        self.__name__ = fget.__name__
-        self.__module__ = fget.__module__
-
-    def __get__(self, obj, cls):
-        if obj is None:
-            return self
-        obj.__dict__[self.__name__] = result = self.fget(obj)
-        return result
 
 
 class Parameters(object):

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -19,6 +19,7 @@ import gem
 from gem.utils import cached_property, unset_attribute
 
 from tsfc.fiatinterface import create_element, create_quadrature, as_fiat_cell
+from tsfc.kernel_interface import ProxyKernelInterface
 from tsfc.modified_terminals import analyse_modified_terminal
 from tsfc import compat
 from tsfc import ufl2gem
@@ -118,7 +119,7 @@ class TabulationManager(object):
         return self.tables[key]
 
 
-class Parameters(object):
+class Parameters(ProxyKernelInterface):
     keywords = ('cell',
                 'fiat_cell',
                 'integration_dim',
@@ -129,14 +130,15 @@ class Parameters(object):
                 'weights',
                 'point_index',
                 'argument_indices',
-                'coefficient',
-                'cell_orientation',
-                'facet_number',
                 'cellvolume',
                 'facetarea',
                 'index_cache')
 
     def __init__(self, **kwargs):
+        # Initialise superclass
+        ProxyKernelInterface.__init__(self, kwargs["kernel_interface"])
+        del kwargs["kernel_interface"]
+
         invalid_keywords = set(kwargs.keys()) - set(Parameters.keywords)
         if invalid_keywords:
             raise ValueError("unexpected keyword argument '{0}'".format(invalid_keywords.pop()))
@@ -225,18 +227,6 @@ class Parameters(object):
         pass
 
     argument_indices = ()
-
-    @unset_attribute
-    def coefficient(self):
-        pass
-
-    @unset_attribute
-    def cell_orientation(self):
-        pass
-
-    @unset_attribute
-    def facet_number(self):
-        pass
 
     @unset_attribute
     def cellvolume(self):

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -15,7 +15,7 @@ from FIAT.reference_element import make_affine_mapping
 
 import gem
 
-from tsfc.constants import NUMPY_TYPE
+from tsfc.parameters import NUMPY_TYPE
 
 
 @singledispatch

--- a/tsfc/kernel_interface/__init__.py
+++ b/tsfc/kernel_interface/__init__.py
@@ -1,1 +1,26 @@
 from __future__ import absolute_import, print_function, division
+from six import with_metaclass
+
+from abc import ABCMeta, abstractmethod
+
+from gem.utils import make_proxy_class
+
+
+class KernelInterface(with_metaclass(ABCMeta)):
+    """Abstract interface for accessing the GEM expressions corresponding
+    to kernel arguments."""
+
+    @abstractmethod
+    def coefficient(self, ufl_coefficient, restriction):
+        """A function that maps :class:`ufl.Coefficient`s to GEM
+        expressions."""
+
+    @abstractmethod
+    def cell_orientation(self, restriction):
+        """Cell orientation as a GEM expression."""
+
+    @abstractmethod
+    def facet_number(self, restriction):
+        """Facet number as a GEM index."""
+
+ProxyKernelInterface = make_proxy_class('ProxyKernelInterface', KernelInterface)

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -6,8 +6,10 @@ import coffee.base as coffee
 
 import gem
 
+from tsfc.kernel_interface import KernelInterface
 
-class KernelBuilderBase(object):
+
+class KernelBuilderBase(KernelInterface):
     """Helper class for building local assembly kernels."""
 
     def __init__(self, interior_facet=False):

--- a/tsfc/parameters.py
+++ b/tsfc/parameters.py
@@ -5,8 +5,6 @@ import numpy
 
 NUMPY_TYPE = numpy.dtype("double")
 
-_PRECISION = numpy.finfo(NUMPY_TYPE).precision
-
 SCALAR_TYPE = {numpy.dtype("double"): "double",
                numpy.dtype("float32"): "float"}[NUMPY_TYPE]
 
@@ -22,7 +20,7 @@ PARAMETERS = {
     "unroll_indexsum": 3,
 
     # Precision of float printing (number of digits)
-    "precision": _PRECISION,
+    "precision": numpy.finfo(NUMPY_TYPE).precision,
 }
 
 

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -6,14 +6,16 @@ import numpy
 from singledispatch import singledispatch
 
 import ufl
-from ufl import indices, as_tensor
+from ufl import as_tensor, indices, replace
 from ufl.algorithms import compute_form_data as ufl_compute_form_data
+from ufl.algorithms import estimate_total_polynomial_degree
 from ufl.algorithms.apply_function_pullbacks import apply_function_pullbacks
 from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
 from ufl.algorithms.apply_derivatives import apply_derivatives
 from ufl.algorithms.apply_geometry_lowering import apply_geometry_lowering
 from ufl.corealg.map_dag import map_expr_dag
 from ufl.corealg.multifunction import MultiFunction
+from ufl.geometry import QuadratureWeight
 from ufl.classes import (Abs, Argument, CellOrientation, Coefficient,
                          ComponentTensor, Expr, FloatValue, Division,
                          MixedElement, MultiIndex, Product,
@@ -51,6 +53,27 @@ def compute_form_data(form,
         do_estimate_degrees=do_estimate_degrees,
     )
     return fd
+
+
+def one_times(measure):
+    # Workaround for UFL issue #80:
+    # https://bitbucket.org/fenics-project/ufl/issues/80
+    form = 1 * measure
+    fd = compute_form_data(form, do_estimate_degrees=False)
+    itg_data, = fd.integral_data
+    integral, = itg_data.integrals
+    integrand = integral.integrand()
+
+    # UFL considers QuadratureWeight a geometric quantity, and the
+    # general handler for geometric quantities estimates the degree of
+    # the coordinate element.  This would unnecessarily increase the
+    # estimated degree, so we drop QuadratureWeight instead.
+    expression = replace(integrand, {QuadratureWeight(itg_data.domain): 1})
+
+    # Now estimate degree for the preprocessed form
+    degree = estimate_total_polynomial_degree(expression)
+
+    return integrand, degree
 
 
 def preprocess_expression(expression):

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -29,11 +29,14 @@ from tsfc.modified_terminals import (is_modified_terminal,
                                      construct_modified_terminal)
 
 
+preserve_geometry_types = (CellVolume, FacetArea)
+
+
 def compute_form_data(form,
                       do_apply_function_pullbacks=True,
                       do_apply_integral_scaling=True,
                       do_apply_geometry_lowering=True,
-                      preserve_geometry_types=(CellVolume, FacetArea),
+                      preserve_geometry_types=preserve_geometry_types,
                       do_apply_restrictions=True,
                       do_estimate_degrees=True):
     """Preprocess UFL form in a format suitable for TSFC. Return
@@ -85,9 +88,9 @@ def preprocess_expression(expression):
     expression = apply_algebra_lowering(expression)
     expression = apply_derivatives(expression)
     expression = apply_function_pullbacks(expression)
-    expression = apply_geometry_lowering(expression)
+    expression = apply_geometry_lowering(expression, preserve_geometry_types)
     expression = apply_derivatives(expression)
-    expression = apply_geometry_lowering(expression)
+    expression = apply_geometry_lowering(expression, preserve_geometry_types)
     expression = apply_derivatives(expression)
     return expression
 


### PR DESCRIPTION
- Long overdue refactoring of the implementation of `CellVolume` and `FacetArea`
- Workaround for [the UFL degree estimation bug](https://bitbucket.org/fenics-project/ufl/issues/80), so `CellVolume`/`FacetArea` should calculate the correct value even with higher-order coordinates.
- Wires up `CellVolume` in UFL interpolation (#60)
- New `gem.utils` module with useful utilities
- Some post-#63 clean up

Requires firedrakeproject/firedrake#913.