### PR TITLE
Optimise evaluation for cellwise constant quantities

### DIFF
--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -110,9 +110,9 @@ def _select_expression(expressions, index):
             assert all(len(e.children) == len(expr.children) for e in expressions)
             assert len(expr.children) > 0
 
-            return cls(*[_select_expression(nth_children, index)
-                         for nth_children in zip(*[e.children
-                                                   for e in expressions])])
+            return expr.reconstruct(*[_select_expression(nth_children, index)
+                                      for nth_children in zip(*[e.children
+                                                                for e in expressions])])
         elif issubclass(cls, Indexed):
             assert all(e.multiindex == expr.multiindex for e in expressions)
             return Indexed(_select_expression([e.children[0]

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -165,7 +165,7 @@ def translate_argument(terminal, mt, ctx):
     M = ctx.entity_selector(callback, mt.restriction)
     vi = tuple(gem.Index(extent=d) for d in mt.expr.ufl_shape)
     argument_index = ctx.argument_indices[terminal.number()]
-    result = gem.Indexed(M, ctx.point_multiindex + argument_index + vi)
+    result = gem.Indexed(M, argument_index + vi)
     if vi:
         return gem.ComponentTensor(result, vi)
     else:
@@ -190,7 +190,7 @@ def translate_coefficient(terminal, mt, ctx):
 
     alpha = element.get_indices()
     vi = tuple(gem.Index(extent=d) for d in mt.expr.ufl_shape)
-    result = gem.Product(gem.Indexed(M, ctx.point_multiindex + alpha + vi),
+    result = gem.Product(gem.Indexed(M, alpha + vi),
                          gem.Indexed(vec, alpha))
     for i in alpha:
         result = gem.IndexSum(result, i)

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -34,7 +34,6 @@ class Context(ProxyKernelInterface):
                 'point_set',
                 'weight_expr',
                 'precision',
-                'point_multiindex',
                 'argument_indices',
                 'cellvolume',
                 'facetarea',
@@ -66,10 +65,6 @@ class Context(ProxyKernelInterface):
     @cached_property
     def point_set(self):
         return self.quadrature_rule.point_set
-
-    @cached_property
-    def point_multiindex(self):
-        return self.point_set.indices
 
     @cached_property
     def weight_expr(self):
@@ -216,6 +211,6 @@ def compile_ufl(expression, interior_facet=False, point_sum=False, **kwargs):
     translator = Translator(context)
     result = map_expr_dags(translator, expressions)
     if point_sum:
-        for index in context.point_multiindex:
+        for index in context.point_set.indices:
             result = [gem.index_sum(expr, index) for expr in result]
     return result

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -31,6 +31,8 @@ import finat
 
 import ufl
 
+from tsfc.ufl_utils import spanning_degree
+
 
 __all__ = ("create_element", "supported_elements", "as_fiat_cell")
 
@@ -66,7 +68,7 @@ def fiat_compat(element):
     from tsfc.fiatinterface import create_element
     from finat.fiat_elements import FiatElementBase
     cell = as_fiat_cell(element.cell())
-    finat_element = FiatElementBase(cell, element.degree())
+    finat_element = FiatElementBase(cell, spanning_degree(element))
     finat_element._fiat_element = create_element(element)
     return finat_element
 

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -15,8 +15,6 @@ from FIAT.reference_element import make_affine_mapping
 
 import gem
 
-from finat.point_set import restore_shape
-
 from tsfc.parameters import NUMPY_TYPE
 
 
@@ -107,9 +105,12 @@ def translate_cell_coordinate(terminal, mt, params):
     # This destroys the structure of the quadrature points, but since
     # this code path is only used to implement CellCoordinate in facet
     # integrals, hopefully it does not matter much.
+    point_shape = tuple(index.extent for index in ps.indices)
+
     def callback(entity_id):
         t = params.fiat_cell.get_entity_transform(params.integration_dim, entity_id)
-        return gem.Literal(restore_shape(asarray(list(map(t, ps.points))), ps))
+        data = asarray(list(map(t, ps.points)))
+        return gem.Literal(data.reshape(point_shape + data.shape[1:]))
 
     return gem.partial_indexed(params.entity_selector(callback, mt.restriction),
                                ps.indices)

--- a/tsfc/geometric.py
+++ b/tsfc/geometric.py
@@ -100,19 +100,19 @@ def translate_cell_edge_vectors(terminal, mt, params):
 
 @translate.register(CellCoordinate)
 def translate_cell_coordinate(terminal, mt, params):
+    ps = params.point_set
     if params.integration_dim == params.fiat_cell.get_dimension():
-        return params.point_set.expression
+        return ps.expression
 
     # This destroys the structure of the quadrature points, but since
     # this code path is only used to implement CellCoordinate in facet
     # integrals, hopefully it does not matter much.
     def callback(entity_id):
-        ps = params.point_set
         t = params.fiat_cell.get_entity_transform(params.integration_dim, entity_id)
         return gem.Literal(restore_shape(asarray(list(map(t, ps.points))), ps))
 
     return gem.partial_indexed(params.entity_selector(callback, mt.restriction),
-                               params.point_multiindex)
+                               ps.indices)
 
 
 @translate.register(FacetCoordinate)


### PR DESCRIPTION
This takes advantage of FInAT/FInAT#13 to optimise the evaluation of cellwise constant quantities -- eliminating one regression w.r.t. mainline TSFC.

Note this pull request is to `finat-old`, not `master`.