### PR TITLE
Revise scalar formatting and rounding rules

### DIFF
--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -41,6 +41,7 @@ def generate(impero_c, index_names, precision, roots=(), argument_indices=()):
     params.declare = impero_c.declare
     params.indices = impero_c.indices
     params.precision = precision
+    params.epsilon = 10.0 * eval("1e-%d" % precision)
     params.roots = roots
     params.argument_indices = argument_indices
 
@@ -298,7 +299,11 @@ def _expression_scalar(expr, parameters):
     if isnan(expr.value):
         return coffee.Symbol("NAN")
     else:
-        return coffee.Symbol(("%%.%dg" % (parameters.precision - 1)) % expr.value)
+        v = expr.value
+        r = round(v, 1)
+        if r and abs(v - r) < parameters.epsilon:
+            v = r  # round to nonzero
+        return coffee.Symbol(("%%.%dg" % parameters.precision) % v)
 
 
 @_expression.register(gem.Variable)


### PR DESCRIPTION
Resolves #64, according to the following suggestion:
>
- Revert commit af4145ab65b68c4609377b8130597cb7d952fee1, i.e. format scalars up to precision digits, rather than precision minus one.
- On the other hand, round floating-point numbers if they are within `epsilon` (= 10 * 10^(-precision)) absolute difference to a **non-zero** integer. This kinda emulates what I think the minus one was supposed to achieve, yet doesn't destroy small (close to zero) numbers, as they could be user input ([FFC #127](https://bitbucket.org/fenics-project/ffc/issues/127)).
