### PR TITLE
Fix the application of the FFC rounding hack

### DIFF
--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -32,6 +32,7 @@ literal_rounding.register(Node)(reuse_if_untouched)
 def literal_rounding_literal(node, self):
     table = node.array
     epsilon = self.epsilon
+    # Copied from FFC (ffc/quadrature/quadratureutils.py)
     table[abs(table) < epsilon] = 0
     table[abs(table - 1.0) < epsilon] = 1.0
     table[abs(table + 1.0) < epsilon] = -1.0

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -182,18 +182,9 @@ def statement_evaluate(leaf, parameters):
             return coffee.Block(ops, open_scope=False)
     elif isinstance(expr, gem.Constant):
         assert parameters.declare[leaf]
-        table = numpy.array(expr.array)
-        # FFC uses one less digits for rounding than for printing
-        epsilon = eval("1e-%d" % (parameters.precision - 1))
-        table[abs(table) < epsilon] = 0
-        table[abs(table - 1.0) < epsilon] = 1.0
-        table[abs(table + 1.0) < epsilon] = -1.0
-        table[abs(table - 0.5) < epsilon] = 0.5
-        table[abs(table + 0.5) < epsilon] = -0.5
-        init = coffee.ArrayInit(table, parameters.precision)
         return coffee.Decl(SCALAR_TYPE,
                            _decl_symbol(expr, parameters),
-                           init,
+                           coffee.ArrayInit(expr.array, parameters.precision),
                            qualifiers=["static", "const"])
     else:
         code = expression(expr, parameters, top=True)

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -292,20 +292,7 @@ def _expression_scalar(expr, parameters):
     if isnan(expr.value):
         return coffee.Symbol("NAN")
     else:
-        value = float(expr.value)
-        # FFC uses one less digits for rounding than for printing
-        epsilon = eval("1e-%d" % (parameters.precision - 1))
-        if abs(value) < epsilon:
-            value = 0
-        if abs(value - 1.0) < epsilon:
-            value = 1.0
-        if abs(value + 1.0) < epsilon:
-            value = -1.0
-        if abs(value - 0.5) < epsilon:
-            value = 0.5
-        if abs(value + 0.5) < epsilon:
-            value = -0.5
-        return coffee.Symbol(("%%.%dg" % (parameters.precision - 1)) % value)
+        return coffee.Symbol(("%%.%dg" % (parameters.precision - 1)) % expr.value)
 
 
 @_expression.register(gem.Variable)

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -169,6 +169,8 @@ def basis_evaluation(element, ps, derivative=0, entity=None, epsilon=0.0):
         tensor = gem.Indexed(gem.ListTensor(tensor), di)
     else:
         tensor = tensor[()]
+    # A numerical hack that FFC used to apply on FIAT tables still
+    # lives on after ditching FFC and switching to FInAT.
     tensor = ffc_rounding(tensor, epsilon)
     return gem.ComponentTensor(tensor, i + vi + di)
 


### PR DESCRIPTION
This replaces a temporary hack that applied rounding at COFFEE generation, and now applies rounding on the GEM expressions that FInAT returns.