### PR TITLE
Clean up the FInAT branch

### DIFF
--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -34,6 +34,13 @@ class NoopError(Exception):
     pass
 
 
+def preprocess_gem(expressions):
+    """Lower GEM nodes that cannot be translated to C directly."""
+    expressions = optimise.replace_delta(expressions)
+    expressions = optimise.remove_componenttensors(expressions)
+    return expressions
+
+
 def compile_gem(return_variables, expressions, prefix_ordering, remove_zeros=False):
     """Compiles GEM to Impero.
 
@@ -42,9 +49,6 @@ def compile_gem(return_variables, expressions, prefix_ordering, remove_zeros=Fal
     :arg prefix_ordering: outermost loop indices
     :arg remove_zeros: remove zero assignment to return variables
     """
-    expressions = optimise.replace_delta(expressions)
-    expressions = optimise.remove_componenttensors(expressions)
-
     # Remove zeros
     if remove_zeros:
         rv = []

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -167,8 +167,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     ir = list(reduce(gem.Sum, e, gem.Zero()) for e in zip(*irs))
 
     # Need optimised roots for COFFEE
-    ir = opt.replace_delta(ir)
-    ir = opt.remove_componenttensors(ir)
+    ir = impero_utils.preprocess_gem(ir)
 
     # Look for cell orientations in the IR
     if builder.needs_cell_orientations(ir):
@@ -303,6 +302,7 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
     return_var = gem.Variable('A', return_shape)
     return_arg = ast.Decl(SCALAR_TYPE, ast.Symbol('A', rank=return_shape))
     return_expr = gem.Indexed(return_var, return_indices)
+    ir, = impero_utils.preprocess_gem([ir])
     impero_c = impero_utils.compile_gem([return_expr], [ir], return_indices)
     point_index, = point_set.indices
     body = generate_coffee(impero_c, {point_index: 'p'}, parameters["precision"])

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -35,7 +35,7 @@ import ufl
 from ufl.algorithms.elementtransformations import reconstruct_element
 
 
-__all__ = ("create_element", "create_quadrature", "supported_elements", "as_fiat_cell")
+__all__ = ("create_element", "supported_elements", "as_fiat_cell")
 
 
 supported_elements = {
@@ -152,30 +152,6 @@ def as_fiat_cell(cell):
     if not isinstance(cell, ufl.AbstractCell):
         raise ValueError("Expecting a UFL Cell")
     return FIAT.ufc_cell(cell)
-
-
-def create_quadrature(cell, degree, scheme="default"):
-    """Create a quadrature rule.
-
-    :arg cell: The FIAT cell.
-    :arg degree: The degree of polynomial that should be integrated
-        exactly by the rule.
-    :kwarg scheme: optional scheme to use (either ``"default"``, or
-         ``"canonical"``).
-
-    .. note ::
-
-       If the cell is a tensor product cell, the degree should be a
-       tuple, indicating the degree in each direction of the tensor
-       product.
-    """
-    if scheme not in ("default", "canonical"):
-        raise ValueError("Unknown quadrature scheme '%s'" % scheme)
-
-    rule = FIAT.create_quadrature(cell, degree, scheme)
-    if len(rule.get_points()) > 900:
-        raise RuntimeError("Requested a quadrature rule with %d points" % len(rule.get_points()))
-    return rule
 
 
 @singledispatch

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -26,13 +26,13 @@ from __future__ import absolute_import, print_function, division
 from singledispatch import singledispatch
 import weakref
 
-import FIAT
 import finat
 from finat.fiat_elements import FiatElementBase
 
 import ufl
 from ufl.algorithms.elementtransformations import reconstruct_element
 
+from tsfc.fiatinterface import as_fiat_cell
 from tsfc.ufl_utils import spanning_degree
 
 
@@ -68,15 +68,6 @@ class FiatElementWrapper(FiatElementBase):
     @property
     def degree(self):
         return self._degree or super(FiatElementWrapper, self).degree
-
-
-def as_fiat_cell(cell):
-    """Convert a ufl cell to a FIAT cell.
-
-    :arg cell: the :class:`ufl.Cell` to convert."""
-    if not isinstance(cell, ufl.AbstractCell):
-        raise ValueError("Expecting a UFL Cell")
-    return FIAT.ufc_cell(cell)
 
 
 def fiat_compat(element):

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -28,6 +28,7 @@ import weakref
 
 import FIAT
 import finat
+from finat.fiat_elements import FiatElementBase
 
 import ufl
 from ufl.algorithms.elementtransformations import reconstruct_element
@@ -59,6 +60,16 @@ element is supported, but must be handled specially because it doesn't
 have a direct FIAT equivalent."""
 
 
+class FiatElementWrapper(FiatElementBase):
+    def __init__(self, element, degree=None):
+        super(FiatElementWrapper, self).__init__(element)
+        self._degree = degree
+
+    @property
+    def degree(self):
+        return self._degree or super(FiatElementWrapper, self).degree
+
+
 def as_fiat_cell(cell):
     """Convert a ufl cell to a FIAT cell.
 
@@ -70,11 +81,8 @@ def as_fiat_cell(cell):
 
 def fiat_compat(element):
     from tsfc.fiatinterface import create_element
-    from finat.fiat_elements import FiatElementBase
-    cell = as_fiat_cell(element.cell())
-    finat_element = FiatElementBase(cell, spanning_degree(element))
-    finat_element._fiat_element = create_element(element)
-    return finat_element
+    return FiatElementWrapper(create_element(element),
+                              degree=spanning_degree(element))
 
 
 @singledispatch

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -95,12 +95,6 @@ def preprocess_expression(expression):
     return expression
 
 
-def is_element_affine(ufl_element):
-    """Tells if a UFL element is affine."""
-    affine_cells = ["interval", "triangle", "tetrahedron"]
-    return ufl_element.cell().cellname() in affine_cells and ufl_element.degree() == 1
-
-
 class SpatialCoordinateReplacer(MultiFunction):
     """Replace SpatialCoordinate nodes with the ReferenceValue of a
     Coefficient.  Assumes that the coordinate element only needs
@@ -208,9 +202,6 @@ class CoefficientSplitter(MultiFunction, ModifiedTerminalMixin):
 def split_coefficients(expression, split):
     """Split mixed coefficients, so mixed elements need not be
     implemented."""
-    if split is None:
-        # Skip this step for DOLFIN
-        return expression
     splitter = CoefficientSplitter(split)
     return map_expr_dag(splitter, expression)
 


### PR DESCRIPTION
- Adopt FInAT/FInAT#18.
- Remove affine index groups. We can revert this in future for Bernstein, but they are not used for now.
- Make GEM lowering a separate step from GEM compilation, this helps to avoid some duplicate traversals and thus make compilation a bit faster.
- Remove some functions that are no longer used.