### PR TITLE
Update UFC kernel interface

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -735,10 +735,12 @@ def reshape(var, *shapes):
         variable = var
         indexes = tuple(Index(extent=extent) for extent in variable.shape)
         dim2idxs = tuple((0, ((index, 1),)) for index in indexes)
+        assert len(indexes) == len(shapes)
         shape_of = dict(zip(indexes, shapes))
     elif isinstance(var, ComponentTensor) and isinstance(var.children[0], FlexiblyIndexed):
         variable = var.children[0].children[0]
         dim2idxs = var.children[0].dim2idxs
+        assert len(var.multiindex) == len(shapes)
         shape_of = dict(zip(var.multiindex, shapes))
     else:
         raise ValueError("Cannot view {} objects.".format(type(var).__name__))
@@ -775,10 +777,12 @@ def view(var, *slices):
         variable = var
         indexes = tuple(Index(extent=extent) for extent in variable.shape)
         dim2idxs = tuple((0, ((index, 1),)) for index in indexes)
+        assert len(indexes) == len(slices)
         slice_of = dict(zip(indexes, slices))
     elif isinstance(var, ComponentTensor) and isinstance(var.children[0], FlexiblyIndexed):
         variable = var.children[0].children[0]
         dim2idxs = var.children[0].dim2idxs
+        assert len(var.multiindex) == len(slices)
         slice_of = dict(zip(var.multiindex, slices))
     else:
         raise ValueError("Cannot view {} objects.".format(type(var).__name__))
@@ -791,7 +795,6 @@ def view(var, *slices):
         for idx in idxs:
             index, stride = idx
             assert isinstance(index, Index)
-            assert index.extent is not None
             dim = index.extent
             s = slice_of[index]
             start = s.start or 0

--- a/tests/test_flexibly_indexed.py
+++ b/tests/test_flexibly_indexed.py
@@ -72,6 +72,26 @@ def test_view_reshape(vector):
     assert [(1,), (2,), (5,), (6,)] == actual
 
 
+def test_reshape_shape(vector):
+    expression = gem.reshape(gem.view(vector, slice(5, 11)), (3, 2))
+    assert expression.shape == (3, 2)
+
+    actual = [convert(expression, multiindex)
+              for multiindex in numpy.ndindex(expression.shape)]
+
+    assert [(i,) for i in range(5, 11)] == actual
+
+
+def test_reshape_reshape(vector):
+    expression = gem.reshape(gem.reshape(vector, (4, 3)), (2, 2), (3,))
+    assert expression.shape == (2, 2, 3)
+
+    actual = [convert(expression, multiindex)
+              for multiindex in numpy.ndindex(expression.shape)]
+
+    assert [(i,) for i in range(12)] == actual
+
+
 if __name__ == "__main__":
     import os
     import sys

--- a/tests/test_flexibly_indexed.py
+++ b/tests/test_flexibly_indexed.py
@@ -51,6 +51,27 @@ def test_view(matrix):
     assert list(product(range(3, 8), range(5, 12))) == actual
 
 
+def test_view_view(matrix):
+    expression = gem.view(gem.view(matrix, slice(3, 8), slice(5, 12)),
+                          slice(4), slice(3, 6))
+    assert expression.shape == (4, 3)
+
+    actual = [convert(expression, multiindex)
+              for multiindex in numpy.ndindex(expression.shape)]
+
+    assert list(product(range(3, 7), range(8, 11))) == actual
+
+
+def test_view_reshape(vector):
+    expression = gem.view(gem.reshape(vector, (3, 4)), slice(2), slice(1, 3))
+    assert expression.shape == (2, 2)
+
+    actual = [convert(expression, multiindex)
+              for multiindex in numpy.ndindex(expression.shape)]
+
+    assert [(1,), (2,), (5,), (6,)] == actual
+
+
 if __name__ == "__main__":
     import os
     import sys

--- a/tests/test_flexibly_indexed.py
+++ b/tests/test_flexibly_indexed.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, print_function, division
+from six.moves import range
+
+import gem
+import numpy
+import pytest
+import tsfc
+
+
+parameters = tsfc.coffee.Bunch()
+parameters.names = {}
+
+
+def convert(expression, multiindex):
+    assert not expression.free_indices
+    element = gem.Indexed(expression, multiindex)
+    element, = gem.optimise.remove_componenttensors((element,))
+    return tsfc.coffee.expression(element, parameters).rank
+
+
+@pytest.fixture(scope='module')
+def vector():
+    return gem.Variable('u', (12,))
+
+
+@pytest.fixture(scope='module')
+def matrix():
+    return gem.Variable('A', (10, 12))
+
+
+def test_reshape(vector):
+    expression = gem.reshape(vector, (3, 4))
+    assert expression.shape == (3, 4)
+
+    actual = [convert(expression, multiindex)
+              for multiindex in numpy.ndindex(expression.shape)]
+
+    assert [(i,) for i in range(12)] == actual
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])

--- a/tests/test_flexibly_indexed.py
+++ b/tests/test_flexibly_indexed.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, print_function, division
 from six.moves import range
 
-import gem
+from itertools import product
+
 import numpy
 import pytest
+
+import gem
 import tsfc
 
 
@@ -36,6 +39,16 @@ def test_reshape(vector):
               for multiindex in numpy.ndindex(expression.shape)]
 
     assert [(i,) for i in range(12)] == actual
+
+
+def test_view(matrix):
+    expression = gem.view(matrix, slice(3, 8), slice(5, 12))
+    assert expression.shape == (5, 7)
+
+    actual = [convert(expression, multiindex)
+              for multiindex in numpy.ndindex(expression.shape)]
+
+    assert list(product(range(3, 8), range(5, 12))) == actual
 
 
 if __name__ == "__main__":

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -333,40 +333,27 @@ def _expression_flexiblyindexed(expr, parameters):
     rank = []
     offset = []
     for off, idxs in expr.dim2idxs:
-        if idxs:
-            indices, strides = zip(*idxs)
-            strides = cumulative_strides(strides)
-        else:
-            indices = ()
-            strides = ()
+        for index, stride in idxs:
+            assert isinstance(index, gem.Index)
 
-        iss = []
-        for i, s in zip(indices, strides):
-            if isinstance(i, int):
-                off += i * s
-            elif isinstance(i, gem.Index):
-                iss.append((i, s))
-            else:
-                raise AssertionError("Unexpected index type!")
-
-        if len(iss) == 0:
+        if len(idxs) == 0:
             rank.append(off)
             offset.append((1, 0))
-        elif len(iss) == 1:
-            (i, s), = iss
-            rank.append(parameters.index_names[i])
-            offset.append((s, off))
+        elif len(idxs) == 1:
+            (index, stride), = idxs
+            rank.append(parameters.index_names[index])
+            offset.append((stride, off))
         else:
             parts = []
             if off:
                 parts += [coffee.Symbol(str(off))]
-            for i, s in iss:
-                index_sym = coffee.Symbol(parameters.index_names[i])
-                assert s
-                if s == 1:
+            for index, stride in idxs:
+                index_sym = coffee.Symbol(parameters.index_names[index])
+                assert stride
+                if stride == 1:
                     parts += [index_sym]
                 else:
-                    parts += [coffee.Prod(index_sym, coffee.Symbol(str(s)))]
+                    parts += [coffee.Prod(index_sym, coffee.Symbol(str(stride)))]
             assert parts
             rank.append(reduce(coffee.Sum, parts))
             offset.append((1, 0))

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -323,18 +323,6 @@ def _expression_indexed(expr, parameters):
                           rank=tuple(rank))
 
 
-def cumulative_strides(strides):
-    """Calculate cumulative strides from per-dimension capacities.
-
-    For example:
-
-        [2, 3, 4] ==> [12, 4, 1]
-
-    """
-    temp = numpy.flipud(numpy.cumprod(numpy.flipud(list(strides)[1:])))
-    return list(temp) + [1]
-
-
 @_expression.register(gem.FlexiblyIndexed)
 def _expression_flexiblyindexed(expr, parameters):
     var = expression(expr.children[0], parameters)

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -109,12 +109,6 @@ def convert_finiteelement(element):
     return lmbda(cell, element.degree())
 
 
-# MixedElement case
-@convert.register(ufl.MixedElement)
-def convert_mixedelement(element):
-    raise ValueError("FInAT does not implement generic mixed element.")
-
-
 # VectorElement case
 @convert.register(ufl.VectorElement)
 def convert_vectorelement(element):

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -32,8 +32,10 @@ class KernelBuilderBase(KernelInterface):
         kernel_arg = self.coefficient_map[ufl_coefficient]
         if ufl_coefficient.ufl_element().family() == 'Real':
             return kernel_arg
+        elif not self.interior_facet:
+            return kernel_arg
         else:
-            return gem.partial_indexed(kernel_arg, {None: (), '+': (0,), '-': (1,)}[restriction])
+            return kernel_arg[{'+': 0, '-': 1}[restriction]]
 
     def cell_orientation(self, restriction):
         """Cell orientation as a GEM expression."""

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -10,6 +10,9 @@ import coffee.base as coffee
 
 import gem
 from gem.node import traversal
+from gem.optimise import remove_componenttensors as prune
+
+from finat import TensorFiniteElement
 
 from tsfc.finatinterface import create_element
 from tsfc.kernel_interface.common import KernelBuilderBase as _KernelBuilderBase
@@ -268,31 +271,30 @@ def prepare_coefficient(coefficient, name, interior_facet=False):
 
     finat_element = create_element(coefficient.ufl_element())
 
-    # TODO: move behind the FInAT interface!
-    if hasattr(finat_element, '_base_element'):
-        scalar_shape = finat_element._base_element.index_shape
+    if isinstance(finat_element, TensorFiniteElement):
+        scalar_shape = finat_element.base_element.index_shape
         tensor_shape = finat_element.index_shape[len(scalar_shape):]
     else:
         scalar_shape = finat_element.index_shape
         tensor_shape = ()
-
-    if interior_facet:
-        scalar_shape = (2,) + scalar_shape
+    scalar_size = numpy.prod(scalar_shape, dtype=int)
+    tensor_size = numpy.prod(tensor_shape, dtype=int)
 
     funarg = coffee.Decl(SCALAR_TYPE, coffee.Symbol(name),
                          pointers=[("const", "restrict"), ("restrict",)],
                          qualifiers=["const"])
 
-    scalar_size = numpy.prod(scalar_shape, dtype=int)
-    tensor_size = numpy.prod(tensor_shape, dtype=int)
-    expression = gem.reshape(
-        gem.Variable(name, (scalar_size, tensor_size)),
-        scalar_shape, tensor_shape
-    )
-
-    if interior_facet:
-        expression = (gem.partial_indexed(expression, (0,)),
-                      gem.partial_indexed(expression, (1,)))
+    if not interior_facet:
+        expression = gem.reshape(
+            gem.Variable(name, (scalar_size, tensor_size)),
+            scalar_shape, tensor_shape
+        )
+    else:
+        varexp = gem.Variable(name, (2 * scalar_size, tensor_size))
+        plus = gem.view(varexp, slice(scalar_size), slice(tensor_size))
+        minus = gem.view(varexp, slice(scalar_size, 2 * scalar_size), slice(tensor_size))
+        expression = (gem.reshape(plus, scalar_shape, tensor_shape),
+                      gem.reshape(minus, scalar_shape, tensor_shape))
     return funarg, expression
 
 
@@ -321,26 +323,24 @@ def prepare_arguments(arguments, multiindices, interior_facet=False):
     elements = tuple(create_element(arg.ufl_element()) for arg in arguments)
     shapes = tuple(element.index_shape for element in elements)
 
-    c_shape = numpy.array([numpy.prod(shape, dtype=int) for shape in shapes])
+    def expression(restricted):
+        return gem.Indexed(gem.reshape(restricted, *shapes),
+                           tuple(chain(*multiindices)))
+
+    u_shape = numpy.array([numpy.prod(shape, dtype=int) for shape in shapes])
     if interior_facet:
-        c_shape *= 2
-    c_shape = tuple(c_shape)
+        c_shape = tuple(2 * u_shape)
+        slicez = [[slice(r * s, (r + 1) * s)
+                   for r, s in zip(restrictions, u_shape)]
+                  for restrictions in product((0, 1), repeat=len(arguments))]
+    else:
+        c_shape = tuple(u_shape)
+        slicez = [[slice(s) for s in u_shape]]
 
     funarg = coffee.Decl(SCALAR_TYPE, coffee.Symbol("A", rank=c_shape))
     varexp = gem.Variable("A", c_shape)
-
-    if not interior_facet:
-        flat_multiindex = tuple(chain(*multiindices))
-        expression = gem.Indexed(gem.reshape(varexp, *shapes), flat_multiindex)
-        return funarg, gem.optimise.remove_componenttensors([expression])
-    else:
-        expressions = []
-        for restrictions in product((0, 1), repeat=len(arguments)):
-            shapes_ = tuple((2,) + shape for shape in shapes)
-            flat_multiindex = tuple(chain(*[(restriction,) + multiindex
-                                            for restriction, multiindex in zip(restrictions, multiindices)]))
-            expressions.append(gem.Indexed(gem.reshape(varexp, *shapes_), flat_multiindex))
-        return funarg, gem.optimise.remove_componenttensors(expressions)
+    expressions = [expression(gem.view(varexp, *slices)) for slices in slicez]
+    return funarg, prune(expressions)
 
 
 cell_orientations_coffee_arg = coffee.Decl("int", coffee.Symbol("cell_orientations"),

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -290,6 +290,9 @@ def prepare_coefficient(coefficient, name, interior_facet=False):
         scalar_shape, tensor_shape
     )
 
+    if interior_facet:
+        expression = (gem.partial_indexed(expression, (0,)),
+                      gem.partial_indexed(expression, (1,)))
     return funarg, expression
 
 

--- a/tsfc/mixedelement.py
+++ b/tsfc/mixedelement.py
@@ -80,10 +80,6 @@ class MixedElement(object):
         """Tabulate a mixed element by appropriately splatting
         together the tabulation of the individual elements.
         """
-        # FIXME: Could we reorder the basis functions so that indexing
-        # in the form compiler for mixed interior facets becomes
-        # easier?
-        # Would probably need to redo entity_dofs as well.
         shape = (self.space_dimension(), self.num_components(), len(points))
 
         output = {}

--- a/tsfc/mixedelement.py
+++ b/tsfc/mixedelement.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# This file was modified from FFC
+# (http://bitbucket.org/fenics-project/ffc), copyright notice
+# reproduced below.
+#
+# Copyright (C) 2005-2010 Anders Logg
+#
+# This file is part of FFC.
+#
+# FFC is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FFC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with FFC. If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, print_function, division
+from six.moves import map
+
+import numpy
+
+from collections import defaultdict
+from operator import add
+from functools import partial
+
+
+class MixedElement(object):
+    """A FIAT-like representation of a mixed element.
+
+    :arg elements: An iterable of FIAT elements.
+
+    This object offers tabulation of the concatenated basis function
+    tables along with an entity_dofs dict."""
+    def __init__(self, elements):
+        self._elements = tuple(elements)
+        self._entity_dofs = None
+
+    def get_reference_element(self):
+        return self.elements()[0].get_reference_element()
+
+    def elements(self):
+        return self._elements
+
+    def space_dimension(self):
+        return sum(e.space_dimension() for e in self.elements())
+
+    def value_shape(self):
+        return (sum(numpy.prod(e.value_shape(), dtype=int) for e in self.elements()), )
+
+    def entity_dofs(self):
+        if self._entity_dofs is not None:
+            return self._entity_dofs
+
+        ret = defaultdict(partial(defaultdict, list))
+
+        dicts = (e.entity_dofs() for e in self.elements())
+
+        offsets = numpy.cumsum([0] + list(e.space_dimension()
+                                          for e in self.elements()),
+                               dtype=int)
+        for i, d in enumerate(dicts):
+            for dim, dofs in d.items():
+                for ent, off in dofs.items():
+                    ret[dim][ent] += list(map(partial(add, offsets[i]),
+                                              off))
+        self._entity_dofs = ret
+        return self._entity_dofs
+
+    def num_components(self):
+        return self.value_shape()[0]
+
+    def tabulate(self, order, points, entity):
+        """Tabulate a mixed element by appropriately splatting
+        together the tabulation of the individual elements.
+        """
+        # FIXME: Could we reorder the basis functions so that indexing
+        # in the form compiler for mixed interior facets becomes
+        # easier?
+        # Would probably need to redo entity_dofs as well.
+        shape = (self.space_dimension(), self.num_components(), len(points))
+
+        output = {}
+
+        sub_dims = [0] + list(e.space_dimension() for e in self.elements())
+        sub_cmps = [0] + list(numpy.prod(e.value_shape(), dtype=int)
+                              for e in self.elements())
+        irange = numpy.cumsum(sub_dims)
+        crange = numpy.cumsum(sub_cmps)
+
+        for i, e in enumerate(self.elements()):
+            table = e.tabulate(order, points, entity)
+
+            for d, tab in table.items():
+                try:
+                    arr = output[d]
+                except KeyError:
+                    arr = numpy.zeros(shape)
+                    output[d] = arr
+
+                ir = irange[i:i+2]
+                cr = crange[i:i+2]
+                tab = tab.reshape(ir[1] - ir[0], cr[1] - cr[0], -1)
+                arr[slice(*ir), slice(*cr)] = tab
+
+        return output


### PR DESCRIPTION
- Internal representation of `gem.FlexiblyIndexed` changed (@inducer, @rckirby)
- Added convenience functions `gem.view` and `gem.reshape` to easily exploit the capabilities of `gem.FlexiblyIndexed`
- Added unit test for `gem.view` and `gem.reshape`
- `MixedElement` resurrected for use in FEniCS
- Updated UFC kernel interface
- General kernel interface cleanup
