### PR TITLE
Fix pickling of GEM

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -451,6 +451,12 @@ class VariableIndex(IndexBase):
     def __hash__(self):
         return hash((VariableIndex, self.expression))
 
+    def __str__(self):
+        return str(self.expression)
+
+    def __repr__(self):
+        return repr(self.expression)
+
     def __reduce__(self):
         return VariableIndex, (self.expression,)
 

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -455,7 +455,7 @@ class VariableIndex(IndexBase):
         return str(self.expression)
 
     def __repr__(self):
-        return repr(self.expression)
+        return "VariableIndex(%r)" % (self.expression,)
 
     def __reduce__(self):
         return VariableIndex, (self.expression,)

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -59,7 +59,7 @@ class NodeMeta(type):
 class Node(with_metaclass(NodeMeta, NodeBase)):
     """Abstract GEM node class."""
 
-    __slots__ = ('free_indices')
+    __slots__ = ('free_indices',)
 
     def is_equal(self, other):
         """Common subexpression eliminating equality predicate.
@@ -419,10 +419,18 @@ class Index(IndexBase):
         # Allow sorting of free indices in Python 3
         return id(self) < id(other)
 
+    def __getstate__(self):
+        return self.name, self.extent, self.count
+
+    def __setstate__(self, state):
+        self.name, self.extent, self.count = state
+
 
 class VariableIndex(IndexBase):
     """An index that is constant during a single execution of the
     kernel, but whose value is not known at compile time."""
+
+    __slots__ = ('expression',)
 
     def __init__(self, expression):
         assert isinstance(expression, Node)
@@ -442,6 +450,9 @@ class VariableIndex(IndexBase):
 
     def __hash__(self):
         return hash((VariableIndex, self.expression))
+
+    def __reduce__(self):
+        return VariableIndex, (self.expression,)
 
 
 class Indexed(Scalar):

--- a/tests/test_pickle_gem.py
+++ b/tests/test_pickle_gem.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, print_function, division
+from six.moves import cPickle as pickle, range
+import gem
+import numpy
+import pytest
+
+
+@pytest.mark.parametrize('protocol', range(3))
+def test_pickle_gem(protocol):
+    f = gem.VariableIndex(gem.Indexed(gem.Variable('facet', (2,)), (1,)))
+    q = gem.Index()
+    r = gem.Index()
+    _1 = gem.Indexed(gem.Literal(numpy.random.rand(3, 6, 8)), (f, q, r))
+    _2 = gem.Indexed(gem.view(gem.Variable('w', (None, None)), slice(8), slice(1)), (r, 0))
+    expr = gem.ComponentTensor(gem.IndexSum(gem.Product(_1, _2), (r,)), (q,))
+
+    unpickled = pickle.loads(pickle.dumps(expr, protocol))
+    assert repr(expr) == repr(unpickled)
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])


### PR DESCRIPTION
Found a hidden detail in the Python documentation which reveals that pickling in Python need not be a messy chaos.

Testing and saving/restoring running indices is not immaculate yet, but workable. Fixing little annoyances will be possible when we have better textual representation (pretty-printing) tools.

Closes #74.