### PR TITLE
Attempt to do form splitting in TSFC for loo.py

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -106,8 +106,9 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     fake_args = [[Argument(FunctionSpace(arg.ufl_domain(), sub_elem), arg.number())
                   for sub_elem in ufl_utils.unmix_element(arg.ufl_element())]
                  for arg in arguments]
-    for bar, args in zip(itertools.product(*argument_indices), itertools.product(*fake_args)):
-        return_variables.extend(builder.set_arguments(args, bar))
+    for split_indices, split_args in zip(itertools.product(*argument_indices),
+                                         itertools.product(*fake_args)):
+        return_variables.extend(builder.set_arguments(split_args, split_indices))
 
     coordinates = ufl_utils.coordinate_coefficient(mesh)
     builder.set_coordinates(coordinates)

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import, print_function, division
 from six.moves import range
 
 import collections
+import itertools
 import time
 from functools import reduce
 from itertools import chain
 
 from ufl.algorithms import extract_arguments, extract_coefficients
 from ufl.algorithms.analysis import has_type
-from ufl.classes import Form, CellVolume
+from ufl.classes import Form, CellVolume, Argument, FunctionSpace
 from ufl.log import GREEN
 
 import gem
@@ -90,17 +91,23 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     fiat_cell = as_fiat_cell(cell)
     integration_dim, entity_ids = lower_integral_type(fiat_cell, integral_type)
 
-    argument_indices = tuple(tuple(gem.Index(extent=e)
-                                   for e in create_element(arg.ufl_element()).index_shape)
+    argument_indices = tuple(tuple(tuple(gem.Index(extent=e)
+                                         for e in create_element(elem).index_shape)
+                                   for elem in ufl_utils.unmix_element(arg.ufl_element()))
                              for arg in arguments)
-    flat_argument_indices = tuple(chain(*argument_indices))
+    flat_argument_indices = tuple(chain(*chain(*argument_indices)))
     quadrature_indices = []
 
     # Dict mapping domains to index in original_form.ufl_domains()
     domain_numbering = form_data.original_form.domain_numbering()
     builder = interface.KernelBuilder(integral_type, integral_data.subdomain_id,
                                       domain_numbering[integral_data.domain])
-    return_variables = builder.set_arguments(arguments, argument_indices)
+    return_variables = []
+    fake_args = [[Argument(FunctionSpace(arg.ufl_domain(), sub_elem), arg.number())
+                  for sub_elem in ufl_utils.unmix_element(arg.ufl_element())]
+                 for arg in arguments]
+    for bar, args in zip(itertools.product(*argument_indices), itertools.product(*fake_args)):
+        return_variables.extend(builder.set_arguments(args, bar))
 
     coordinates = ufl_utils.coordinate_coefficient(mesh)
     builder.set_coordinates(coordinates)
@@ -119,13 +126,13 @@ def compile_integral(integral_data, form_data, prefix, parameters,
                       precision=parameters["precision"],
                       integration_dim=integration_dim,
                       entity_ids=entity_ids,
-                      argument_indices=argument_indices,
+                      # argument_indices=argument_indices,
                       index_cache=index_cache)
 
     kernel_cfg["facetarea"] = facetarea_generator(mesh, coordinates, kernel_cfg, integral_type)
     kernel_cfg["cellvolume"] = cellvolume_generator(mesh, coordinates, kernel_cfg)
 
-    irs = []
+    irs = collections.defaultdict(list)
     for integral in integral_data.integrals:
         params = {}
         # Record per-integral parameters
@@ -157,14 +164,19 @@ def compile_integral(integral_data, form_data, prefix, parameters,
 
         config = kernel_cfg.copy()
         config.update(quadrature_rule=quad_rule)
-        ir = fem.compile_ufl(integrand, interior_facet=interior_facet, **config)
-        if parameters["unroll_indexsum"]:
-            ir = opt.unroll_indexsum(ir, max_extent=parameters["unroll_indexsum"])
-        ir = [gem.index_sum(expr, quadrature_multiindex) for expr in ir]
-        irs.append(ir)
+        for idx, expr in ufl_utils.split_expression(integrand, arguments):
+            config_ = config.copy()
+            config_.update(argument_indices=tuple(foo[ii] for foo, ii in zip(argument_indices, idx)))
+            ir = fem.compile_ufl(expr, interior_facet=interior_facet, **config_)
+            if parameters["unroll_indexsum"]:
+                ir = opt.unroll_indexsum(ir, max_extent=parameters["unroll_indexsum"])
+            ir = [gem.index_sum(expr, quadrature_multiindex) for expr in ir]
+            irs[idx].append(ir)
 
     # Sum the expressions that are part of the same restriction
-    ir = list(reduce(gem.Sum, e, gem.Zero()) for e in zip(*irs))
+    ir = list(reduce(gem.Sum, e, gem.Zero())
+              for idx in sorted(irs)
+              for e in zip(*irs[idx]))
 
     # Need optimised roots for COFFEE
     ir = impero_utils.preprocess_gem(ir)
@@ -178,9 +190,10 @@ def compile_integral(integral_data, form_data, prefix, parameters,
                                         remove_zeros=True)
 
     # Generate COFFEE
-    index_names = [(si, name + str(n))
-                   for index, name in zip(argument_indices, ['j', 'k'])
-                   for n, si in enumerate(index)]
+    index_names = []
+    # index_names = [(si, name + str(n))
+    #                for index, name in zip(argument_indices, ['j', 'k'])
+    #                for n, si in enumerate(index)]
     if len(quadrature_indices) == 1:
         index_names.append((quadrature_indices[0], 'ip'))
     else:

--- a/tsfc/tsfc_to_loopy.py
+++ b/tsfc/tsfc_to_loopy.py
@@ -368,15 +368,16 @@ def tsfc_to_loopy(ir, output_names="A", kernel_name="tsfc_kernel"):
         name=kernel_name)
 
     if 1:  # Add an option to turn this off later if we want.
-        A0writes = [ins for ins in knl.instructions
-                    if ins.assignee.aggregate.name == "A0"]
-        assert len(A0writes) == 1
+        for outname in output_names:
+            Aiwrites = [ins for ins in knl.instructions
+                        if ins.assignee.aggregate.name == outname]
+            assert len(Aiwrites) == 1
 
-        # turn x = x + y into x = y
-        insn = A0writes[0]
-        rvalue = insn.expression
-        newrvalue = rvalue.children[1]
-        insn.expression = newrvalue
+            # turn x = x + y into x = y
+            insn = Aiwrites[0]
+            rvalue = insn.expression
+            newrvalue = rvalue.children[1]
+            insn.expression = newrvalue
 
     return knl
 

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -1,6 +1,10 @@
 """Utilities for preprocessing UFL objects."""
 
 from __future__ import absolute_import, print_function, division
+from six.moves import range, zip
+
+import collections
+import itertools
 
 import numpy
 from singledispatch import singledispatch
@@ -17,10 +21,11 @@ from ufl.corealg.map_dag import map_expr_dag
 from ufl.corealg.multifunction import MultiFunction
 from ufl.geometry import QuadratureWeight
 from ufl.classes import (Abs, Argument, CellOrientation, Coefficient,
-                         ComponentTensor, Expr, FloatValue, Division,
-                         MixedElement, MultiIndex, Product,
-                         ReferenceValue, ScalarValue, Sqrt, Zero,
-                         CellVolume, FacetArea)
+                         ComponentTensor, Expr, FloatValue,
+                         FunctionSpace, Division, MixedElement,
+                         MultiIndex, Product, ReferenceValue,
+                         ScalarValue, Sqrt, Zero, CellVolume,
+                         FacetArea)
 
 from gem.node import MemoizerArg
 
@@ -204,6 +209,86 @@ def split_coefficients(expression, split):
     implemented."""
     splitter = CoefficientSplitter(split)
     return map_expr_dag(splitter, expression)
+
+
+class ArgumentReplacer(MultiFunction, ModifiedTerminalMixin):
+    def __init__(self, indices):
+        MultiFunction.__init__(self)
+        self._indices = tuple(indices)
+
+    expr = MultiFunction.reuse_if_untouched
+
+    def modified_terminal(self, o):
+        mt = analyse_modified_terminal(o)
+        terminal = mt.terminal
+
+        if not isinstance(terminal, Argument):
+            # Only replace arguments
+            return o
+
+        if type(terminal.ufl_element()) != MixedElement:
+            # Only replace mixed arguments
+            return o
+
+        # Reference value expected
+        assert mt.reference_value
+
+        # Derivative indices
+        beta = indices(mt.local_derivatives)
+
+        # Dimension
+        dim = terminal.ufl_domain().ufl_cell().topological_dimension()
+
+        # Selected sub element
+        i = self._indices[terminal.number()]
+
+        components = []
+        for j, sub_elem in enumerate(terminal.ufl_element().sub_elements()):
+            if i == j:
+                arg = Argument(FunctionSpace(terminal.ufl_domain(), sub_elem), terminal.number())
+                # Apply terminal modifiers to the subargument
+                component = construct_modified_terminal(mt, arg)
+                # Collect components of the subargument
+                for alpha in numpy.ndindex(sub_elem.reference_value_shape()):
+                    # New modified terminal: component[alpha + beta]
+                    components.append(component[alpha + beta])
+            else:
+                # Fill space with zeros
+                for alpha in numpy.ndindex(sub_elem.reference_value_shape()):
+                    components.append(Zero(free_indices=tuple(index.count() for index in beta),
+                                           index_dimensions=tuple(dim for index in beta)))
+        # Repack derivative indices to shape
+        c, = indices(1)
+        return ComponentTensor(as_tensor(components)[c], MultiIndex((c,) + beta))
+
+
+SplitExpression = collections.namedtuple("SplitExpression", ["indices", "expression"])
+
+
+def split_expression(expression, arguments):
+    index_ranges = []
+    for arg in arguments:
+        if type(arg.ufl_element()) == MixedElement:
+            index_ranges.append(list(range(len(arg.ufl_element().sub_elements()))))
+        else:
+            index_ranges.append([0])
+
+    exprs = []
+    for multiindex in itertools.product(*index_ranges):
+        replacer = ArgumentReplacer(multiindex)
+        exprs.append(SplitExpression(multiindex, map_expr_dag(replacer, expression)))
+    return tuple(exprs)
+
+
+def break_element(element):
+    if type(element) == MixedElement:
+        return list(enumerate(element.sub_elements()))
+    else:
+        return [(0, element)]
+
+
+def unmix_element(element):
+    return list(zip(*break_element(element)))[1]
 
 
 class PickRestriction(MultiFunction, ModifiedTerminalMixin):


### PR DESCRIPTION
Note that the target is `loopy-output`, not `master`.

This is quite a rude sketch to do form splitting and fused kernels inside TSFC. It doesn't work with Firedrake master since it changes the kernel API: due to fusion, kernels from mixed forms expect several arguments for return value (e.g. A0, A1, A2, A3 the four blocks of a mixed form).

@rckirby: please have a look and see if you can make use of this!