### PR TITLE
Coffee optimisation migration

### DIFF
--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -34,10 +34,13 @@ class NoopError(Exception):
     pass
 
 
-def preprocess_gem(expressions):
+def preprocess_gem(expressions, quadrature_indices, argument_indices):
     """Lower GEM nodes that cannot be translated to C directly."""
     expressions = optimise.replace_delta(expressions)
     expressions = optimise.remove_componenttensors(expressions)
+    expressions = optimise.replace_division(expressions)
+    expressions = optimise.optimise_list(expressions, tuple(quadrature_indices), argument_indices)
+
     return expressions
 
 

--- a/gem/node.py
+++ b/gem/node.py
@@ -180,6 +180,27 @@ class Memoizer(object):
             return result
 
 
+class Memoizer_cf(object):
+    """Memoizer for count_flop() function. Returns 0 if the node has already been counted once
+
+    :arg function: a function with parameters (value, rec), where
+                   ``rec`` is expected to be a function used for
+                   recursive calls.
+    :returns: a function with working recursion and caching
+    """
+    def __init__(self, function):
+        self.cache = {}
+        self.function = function
+
+    def __call__(self, node):
+        if node in self.cache:
+            return 0
+        else:
+            result = self.function(node, self)
+            self.cache[node] = result
+            return result
+
+
 class MemoizerArg(object):
     """Caching wrapper for functions with overridable recursive calls
     and an argument.  The lifetime of the cache is the lifetime of the

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,3 +1,4 @@
 numpy
 singledispatch
 six
+PuLP

--- a/tests/test_gem_optimise.py
+++ b/tests/test_gem_optimise.py
@@ -1,0 +1,152 @@
+from __future__ import absolute_import, print_function, division
+
+import pytest
+
+from gem.gem import Index, Indexed, Product, Variable, Division, Literal, Sum, IndexSum
+from gem.optimise import replace_division, reassociate_product, optimise, count_flop
+
+
+def test_replace_div():
+    i = Index()
+    A = Variable('A', ())
+    B = Variable('B', (6,))
+    Bi = Indexed(B, (i,))
+    d = Division(Bi, A)
+    result = replace_division([d])[0]
+
+    assert isinstance(result, Product)
+    assert isinstance(result.children[1], Division)
+
+
+def test_reassociate_product():
+    """Test recursive reassociation of products according to the rank of the
+    factors. For example: ::
+
+        C[i,j]*(D[i,j,k] + Q[i,j]*t*P[i])*A*B[i]
+
+    becomes: ::
+
+        A*B[i]*C[i,j]*(D[i,j,k] + t*P[i]*Q[i,j])
+
+    """
+    i = Index()
+    j = Index()
+    k = Index()
+    A = Variable('A', ())
+    Bi = Indexed(Variable('B', (6,)), (i,))
+    Cij = Indexed(Variable('C', (6, 6)), (i, j))
+    Dijk = Indexed(Variable('D', (6, 6, 6)), (i, j, k))
+    Pi = Indexed(Variable('P', (6,)), (i,))
+    Qij = Indexed(Variable('Q', (6, 6)), (i, j))
+    t = Literal(8)
+    p = Product(Product(Product(Cij, Sum(Dijk, Product(Product(Qij, t), Pi))), A), Bi)
+    result = reassociate_product([p])[0]
+    # D[i,j,k] + t*P[i]*Q[i,j]
+    assert isinstance(result.children[1], Sum)
+    # t
+    assert result.children[1].children[1].children[0].children[0] == t
+    # Q[i,j]
+    assert result.children[1].children[1].children[1] == Qij
+    # A
+    assert result.children[0].children[0].children[0] == A
+    # B[i]
+    assert result.children[0].children[0].children[1] == Bi
+    # C[i,j]
+    assert result.children[0].children[1] == Cij
+
+
+def test_optimise():
+    I = J = 10
+    i = Index('i', I)
+    j = Index('j', J)
+    B = Variable('b', (J,))
+    C = Variable('c', (I,))
+    D = Variable('d', (I,))
+    # E = Variable('e', (I,))
+    Bj = Indexed(B, (j,))
+    Ci = Indexed(C, (i,))
+    Di = Indexed(D, (i,))
+    # Ei = Indexed(E, (i,))
+    S = Sum(Product(Bj, Ci), Product(Bj, Di))
+    expr = IndexSum(S, (i,))
+    result = optimise(expr, (i, ), ((j, ), ))
+    assert count_flop(result) == 110
+
+
+# def test_factorise():
+#     """Test factorising a summation. For example: ::
+#
+#         A[i] + A[i]*B[j] + A[i]*(C[j]+D[j]) + A[i]*E[i]*F[i] + G[i]
+#
+#     becomes: ::
+#
+#         A[i] * (1 + B[j] + C[j] + D[j] + E[i]*F[i]) + G[i]
+#
+#     """
+#     i = Index()
+#     j = Index()
+#     A = Variable('A', (6,))
+#     B = Variable('B', (6,))
+#     C = Variable('C', (6,))
+#     D = Variable('D', (6,))
+#     E = Variable('E', (6,))
+#     F = Variable('F', (6,))
+#     G = Variable('G', (6,))
+#     Ai = Indexed(A, (i,))
+#     Bj = Indexed(B, (j,))
+#     Cj = Indexed(C, (j,))
+#     Dj = Indexed(D, (j,))
+#     Ei = Indexed(E, (i,))
+#     Fi = Indexed(F, (i,))
+#     Gi = Indexed(G, (i,))
+#     p1 = Product(Ai, Bj)
+#     p2 = Product(Ai, Sum(Cj, Dj))
+#     p3 = Product(Ei, Fi)
+#     s = Sum(Sum(Sum(Sum(p1, p2), Product(Ai, p3)), Ai), Gi)
+#     result = factorise(s)
+#     # G[i]
+#     assert result.children[1] == Gi
+#     # A[i]
+#     assert result.children[0].children[0] == Ai
+#     # 1
+#     assert result.children[0].children[1].children[1] == Literal(1)
+#     # E[i]*F[i]
+#     assert result.children[0].children[1].children[0].children[1] == p3
+#     # B[j]+C[j]+D[j]
+#     assert result.children[0].children[1].children[0].children[0] == Sum(Bj, Sum(Cj, Dj))
+#
+#
+# def test_factorise_recursion():
+#     """Test recursive factorisation. For example: ::
+#
+#         A[i]*C[i] + A[i]*D[i] + B[i]*C[i] + B[i]*D[i]
+#
+#     becomes: ::
+#
+#         (A[i]+B[i]) * (C[i]+D[i])
+#
+#     """
+#     i = Index()
+#     A = Variable('A', (6,))
+#     B = Variable('B', (6,))
+#     C = Variable('C', (6,))
+#     D = Variable('D', (6,))
+#     Ai = Indexed(A, (i,))
+#     Bi = Indexed(B, (i,))
+#     Ci = Indexed(C, (i,))
+#     Di = Indexed(D, (i,))
+#     p1 = Product(Ai, Ci)
+#     p2 = Product(Ai, Di)
+#     p3 = Product(Bi, Ci)
+#     p4 = Product(Bi, Di)
+#     s = reduce(Sum, [p1, p2, p3, p4])
+#     result = factorise(s)
+#     assert isinstance(result, Product)
+#     assert result.children[0] == Sum(Ci, Di)
+#     assert result.children[1] == Sum(Bi, Ai)
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -167,7 +167,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     ir = list(reduce(gem.Sum, e, gem.Zero()) for e in zip(*irs))
 
     # Need optimised roots for COFFEE
-    ir = impero_utils.preprocess_gem(ir)
+    ir = impero_utils.preprocess_gem(ir, quadrature_indices, argument_indices)
 
     # Look for cell orientations in the IR
     if builder.needs_cell_orientations(ir):
@@ -302,7 +302,7 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
     return_var = gem.Variable('A', return_shape)
     return_arg = ast.Decl(SCALAR_TYPE, ast.Symbol('A', rank=return_shape))
     return_expr = gem.Indexed(return_var, return_indices)
-    ir, = impero_utils.preprocess_gem([ir])
+    ir, = impero_utils.preprocess_gem([ir], (), ())
     impero_c = impero_utils.compile_gem([return_expr], [ir], return_indices)
     point_index, = point_set.indices
     body = generate_coffee(impero_c, {point_index: 'p'}, parameters["precision"])

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -231,7 +231,7 @@ def _(element, vector_is_mixed):
                                 create_element(B, vector_is_mixed))
 
 
-@convert.register(ufl.BrokenElement) # noqa
+@convert.register(ufl.BrokenElement)  # noqa
 def _(element, vector_is_mixed):
     return supported_elements[element.family()](create_element(element._element,
                                                                vector_is_mixed))


### PR DESCRIPTION
#### clean commit for PR to squash numerous commits and separate latex printing changes

This commit migrates loop optimisations in coffee to gem.

### Test if functionalities are migrated

Results of flops comparison are in the attached file result.txt (actually it is a csv file, which cannot be uploaded).

The result shows that gem.optimise() matches or betters coffee level 2 by and large. It also demonstrates that coffee level 2 cannot further optimise ASTs generated by gem.optimise(). There are some cases for which gem.optimise() are slightly worse. These can be solved by checking if factorisation is profitable at each step. As it tends to only affect simple forms with small number of flops, and the differences are not large, I have commented out the code for now. Will revisit this later.

### Major problem
pre-evaluations of tensors reduces numerical precision in some cases, as a result, these tests fails in the firedrake test suits

regression/test_geometric_strong_bcs.py::test_dg_advection[left-1-False]
regression/test_hybridisation.py::test_hybridisation[2]
regression/test_manifolds.py::test_manifold_parallel
regression/test_poisson_strong_bcs.py
regression/test_poisson_strong_bcs_nitsche.py::test_poisson_nitsche[1-False]
regression/test_python_parloop.py::test_python_parloop_vector
regression/test_slate_hybridization.py::test_slate_hybridization[2]

In addition, several others which use errornorm() fails due to taking square root of (tiny) negative numbers. Not sure if these can be eliminated by some clever tricks in choosing an order to contract the tensors, or purely bad luck with floating point numbers.

### Minor problems:

- Performance can be improved further. Currently 3D hyperelasticity takes ~20 seconds. There are significant scope for code optimisation to get that time down, such as reusing the internal data structure of list of factors.
- Several subtle cases to refine further, e.g. Power nodes are not analysed yet (might be beneficial to expand the product).
- Pre-evaluation only works when the inner IndexSum is expanded already.

[result.txt](https://github.com/firedrakeproject/tsfc/files/787955/result.txt)