### PR TITLE
Add GEM utilities for refactorisation

### DIFF
--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, division
 from six import itervalues
 from six.moves import filter, intern, map, zip
 
-from collections import OrderedDict, deque, namedtuple
+from collections import OrderedDict, namedtuple
 from functools import reduce
 from itertools import chain, permutations, product
 
@@ -298,22 +298,8 @@ def contraction(expression):
     # Eliminate annoying ComponentTensors
     expression, = remove_componenttensors([expression])
 
-    # Flatten a product tree
-    sum_indices = []
-    factors = []
-
-    queue = deque([expression])
-    while queue:
-        expr = queue.popleft()
-        if isinstance(expr, IndexSum):
-            queue.append(expr.children[0])
-            sum_indices.extend(expr.multiindex)
-        elif isinstance(expr, Product):
-            queue.extend(expr.children)
-        else:
-            factors.append(expr)
-
-    return sum_factorise(*delta_elimination(sum_indices, factors))
+    # Flatten product tree, eliminate deltas, sum factorise
+    return sum_factorise(*delta_elimination(*traverse_product(expression)))
 
 
 def traverse_product(expression, stop_at=None):

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -372,7 +372,7 @@ class FactorisationError(Exception):
 
 def collect_monomials(expression, classifier):
     def stop_at(expr):
-        return classifier(expr) == OTHER
+        return classifier(expr) != COMPOUND
     common_indices, terms = traverse_product(expression, stop_at=stop_at)
 
     common_atomics = []

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -365,8 +365,8 @@ def traverse_product(expression, stop_at=None):
             if dividend == one:
                 terms.append(expr)
             else:
-                terms.append(Division(one, divisor))
-                terms.append(dividend)
+                stack.append(Division(one, divisor))
+                stack.append(dividend)
         else:
             terms.append(expr)
 

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -2,17 +2,17 @@
 expressions."""
 
 from __future__ import absolute_import, print_function, division
-from six import iteritems, itervalues
-from six.moves import filter, intern, map, zip
+from six import itervalues
+from six.moves import filter, map, zip
 
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import OrderedDict
 from functools import reduce
-from itertools import combinations, permutations, product
+from itertools import combinations, permutations
 
 import numpy
 from singledispatch import singledispatch
 
-from gem.node import Memoizer, MemoizerArg, reuse_if_untouched, reuse_if_untouched_arg, traversal
+from gem.node import Memoizer, MemoizerArg, reuse_if_untouched, reuse_if_untouched_arg
 from gem.gem import (Node, Terminal, Failure, Identity, Literal, Zero,
                      Product, Sum, Comparison, Conditional, Division,
                      Index, VariableIndex, Indexed, FlexiblyIndexed,
@@ -230,7 +230,7 @@ def delta_elimination(sum_indices, factors):
     return sum_indices, [e for e in factors if e != one]
 
 
-def _associate(factors):
+def associate_product(factors):
     """Apply associativity rules to construct an operation-minimal product tree.
 
     For best performance give factors that have different set of free indices.
@@ -295,7 +295,7 @@ def sum_factorise(sum_indices, factors):
             deferred = [t for t in terms if sum_index not in t.free_indices]
 
             # Optimise associativity
-            product, flops_ = _associate(contract)
+            product, flops_ = associate_product(contract)
             term = IndexSum(product, (sum_index,))
             flops += flops_ + numpy.prod([i.extent for i in product.free_indices], dtype=int)
 
@@ -305,7 +305,7 @@ def sum_factorise(sum_indices, factors):
 
         # If some contraction indices were independent, then we may
         # still have several terms at this point.
-        expr, flops_ = _associate(terms)
+        expr, flops_ = associate_product(terms)
         flops += flops_
 
         if flops < best_flops:
@@ -313,23 +313,6 @@ def sum_factorise(sum_indices, factors):
             best_flops = flops
 
     return expression
-
-
-def contraction(expression):
-    """Optimise the contractions of the tensor product at the root of
-    the expression, including:
-
-    - IndexSum-Delta cancellation
-    - Sum factorisation
-
-    This routine was designed with finite element coefficient
-    evaluation in mind.
-    """
-    # Eliminate annoying ComponentTensors
-    expression, = remove_componenttensors([expression])
-
-    # Flatten product tree, eliminate deltas, sum factorise
-    return sum_factorise(*delta_elimination(*traverse_product(expression)))
 
 
 def traverse_product(expression, stop_at=None):
@@ -396,224 +379,21 @@ def traverse_sum(expression, stop_at=None):
     return result
 
 
-# Refactorisation classes
+def contraction(expression):
+    """Optimise the contractions of the tensor product at the root of
+    the expression, including:
 
-ATOMIC = intern('atomic')
-"""Label: the expression need not be broken up into smaller parts"""
+    - IndexSum-Delta cancellation
+    - Sum factorisation
 
-COMPOUND = intern('compound')
-"""Label: the expression must be broken up into smaller parts"""
-
-OTHER = intern('other')
-"""Label: the expression is irrelevant with regards to refactorisation"""
-
-
-Monomial = namedtuple('Monomial', ['sum_indices', 'atomics', 'rest'])
-"""Monomial type, representation of a tensor product with some
-distinguished factors (called atomics).
-
-- sum_indices: indices to sum over
-- atomics: tuple of expressions classified as ATOMIC
-- rest: a single expression classified as OTHER
-
-A :py:class:`Monomial` is a structured description of the expression:
-
-.. code-block:: python
-
-    IndexSum(reduce(Product, atomics, rest), sum_indices)
-
-"""
-
-
-class MonomialSum(object):
-    """Represents a sum of :py:class:`Monomial`s.
-
-    The set of :py:class:`Monomial` summands are represented as a
-    mapping from a pair of unordered ``sum_indices`` and unordered
-    ``atomics`` to a ``rest`` GEM expression.  This representation
-    makes it easier to merge similar monomials.
+    This routine was designed with finite element coefficient
+    evaluation in mind.
     """
-    def __init__(self):
-        # (unordered sum_indices, unordered atomics) -> rest
-        self.monomials = defaultdict(Zero)
+    # Eliminate annoying ComponentTensors
+    expression, = remove_componenttensors([expression])
 
-        # We shall retain ordering for deterministic code generation:
-        #
-        # (unordered sum_indices, unordered atomics) ->
-        #     (ordered sum_indices, ordered atomics)
-        self.ordering = OrderedDict()
-
-    def add(self, sum_indices, atomics, rest):
-        """Updates the :py:class:`MonomialSum` adding a new monomial."""
-        sum_indices = tuple(sum_indices)
-        sum_indices_set = frozenset(sum_indices)
-        # Sum indices cannot have duplicates
-        assert len(sum_indices) == len(sum_indices_set)
-
-        atomics = tuple(atomics)
-        atomics_set = frozenset(atomics)
-        if len(atomics) != len(atomics_set):
-            raise NotImplementedError("MonomialSum does not support duplicate atomics")
-
-        assert isinstance(rest, Node)
-
-        key = (sum_indices_set, atomics_set)
-        self.monomials[key] = Sum(self.monomials[key], rest)
-        self.ordering.setdefault(key, (sum_indices, atomics))
-
-    def __iter__(self):
-        """Iteration yields :py:class:`Monomial` objects"""
-        for key, (sum_indices, atomics) in iteritems(self.ordering):
-            rest = self.monomials[key]
-            yield Monomial(sum_indices, atomics, rest)
-
-    @staticmethod
-    def sum(*args):
-        """Sum of multiple :py:class:`MonomialSum`s"""
-        result = MonomialSum()
-        for arg in args:
-            assert isinstance(arg, MonomialSum)
-            # Optimised implementation: no need to decompose and
-            # reconstruct key.
-            for key, rest in iteritems(arg.monomials):
-                result.monomials[key] = Sum(result.monomials[key], rest)
-            for key, value in iteritems(arg.ordering):
-                result.ordering.setdefault(key, value)
-        return result
-
-    @staticmethod
-    def product(*args):
-        """Product of multiple :py:class:`MonomialSum`s"""
-        result = MonomialSum()
-        for monomials in product(*args):
-            sum_indices = []
-            atomics = []
-            rest = one
-            for s, a, r in monomials:
-                sum_indices.extend(s)
-                atomics.extend(a)
-                rest = Product(r, rest)
-            result.add(sum_indices, atomics, rest)
-        return result
-
-
-class FactorisationError(Exception):
-    """Raised when factorisation fails to achieve some desired form."""
-    pass
-
-
-def _collect_monomials(expression, self):
-    """Refactorises an expression into a sum-of-products form, using
-    distributivity rules (i.e. a*(b + c) -> a*b + a*c).  Expansion
-    proceeds until all "compound" expressions are broken up.
-
-    :arg expression: a GEM expression to refactorise
-    :arg self: function for recursive calls
-
-    :returns: :py:class:`MonomialSum`
-
-    :raises FactorisationError: Failed to break up some "compound"
-                                expressions with expansion.
-    """
-    # Phase 1: Collect and categorise product terms
-    def stop_at(expr):
-        # Break up compounds only
-        return self.classifier(expr) != COMPOUND
-    common_indices, terms = traverse_product(expression, stop_at=stop_at)
-    common_indices = tuple(common_indices)
-
-    common_atomics = []
-    common_others = []
-    compounds = []
-    for term in terms:
-        cls = self.classifier(term)
-        if cls == ATOMIC:
-            common_atomics.append(term)
-        elif cls == COMPOUND:
-            compounds.append(term)
-        elif cls == OTHER:
-            common_others.append(term)
-        else:
-            raise ValueError("Classifier returned illegal value.")
-    common_atomics = tuple(common_atomics)
-
-    # Phase 2: Attempt to break up compound terms into summands
-    sums = []
-    for expr in compounds:
-        summands = traverse_sum(expr, stop_at=stop_at)
-        if len(summands) <= 1:
-            # Compound term is not an addition, avoid infinite
-            # recursion and fail gracefully raising an exception.
-            raise FactorisationError(expr)
-        # Recurse into each summand, concatenate their results
-        sums.append(MonomialSum.sum(*map(self, summands)))
-
-    # Phase 3: Expansion
-    #
-    # Each element of ``sums`` is a MonomialSum.  Expansion produces a
-    # series (representing a sum) of products of monomials.
-    result = MonomialSum()
-    for s, a, r in MonomialSum.product(*sums):
-        all_indices = common_indices + s
-        atomics = common_atomics + a
-
-        # All free indices that appear in atomic terms
-        atomic_indices = set().union(*[atomic.free_indices
-                                       for atomic in atomics])
-
-        # Sum indices that appear in atomic terms
-        # (will go to the result :py:class:`Monomial`)
-        sum_indices = tuple(index for index in all_indices
-                            if index in atomic_indices)
-
-        # Sum indices that do not appear in atomic terms
-        # (can factorise them over atomic terms immediately)
-        rest_indices = tuple(index for index in all_indices
-                             if index not in atomic_indices)
-
-        # Not really sum factorisation, but rather just an optimised
-        # way of building a product.
-        rest = sum_factorise(rest_indices, common_others + [r])
-
-        result.add(sum_indices, atomics, rest)
-    return result
-
-
-def collect_monomials(expressions, classifier):
-    """Refactorises expressions into a sum-of-products form, using
-    distributivity rules (i.e. a*(b + c) -> a*b + a*c).  Expansion
-    proceeds until all "compound" expressions are broken up.
-
-    :arg expressions: GEM expressions to refactorise
-    :arg classifier: a function that can classify any GEM expression
-                     as ``ATOMIC``, ``COMPOUND``, or ``OTHER``.  This
-                     classification drives the factorisation.
-
-    :returns: list of :py:class:`MonomialSum`s
-
-    :raises FactorisationError: Failed to break up some "compound"
-                                expressions with expansion.
-    """
-    # Get ComponentTensors out of the way
-    expressions = remove_componenttensors(expressions)
-
-    # Get ListTensors out of the way
-    must_unroll = []  # indices to unroll
-    for node in traversal(expressions):
-        if isinstance(node, Indexed):
-            child, = node.children
-            if isinstance(child, ListTensor) and classifier(node) == COMPOUND:
-                must_unroll.extend(node.multiindex)
-    if must_unroll:
-        must_unroll = set(must_unroll)
-        expressions = unroll_indexsum(expressions,
-                                      predicate=lambda i: i in must_unroll)
-        expressions = remove_componenttensors(expressions)
-
-    # Finally, refactorise expressions
-    mapper = Memoizer(_collect_monomials)
-    mapper.classifier = classifier
-    return list(map(mapper, expressions))
+    # Flatten product tree, eliminate deltas, sum factorise
+    return sum_factorise(*delta_elimination(*traverse_product(expression)))
 
 
 @singledispatch

--- a/gem/refactorise.py
+++ b/gem/refactorise.py
@@ -142,12 +142,12 @@ def _collect_monomials(expression, self):
     common_others = []
     compounds = []
     for term in terms:
-        cls = self.classifier(term)
-        if cls == ATOMIC:
+        label = self.classifier(term)
+        if label == ATOMIC:
             common_atomics.append(term)
-        elif cls == COMPOUND:
+        elif label == COMPOUND:
             compounds.append(term)
-        elif cls == OTHER:
+        elif label == OTHER:
             common_others.append(term)
         else:
             raise ValueError("Classifier returned illegal value.")

--- a/gem/refactorise.py
+++ b/gem/refactorise.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, division
 from six import iteritems
 from six.moves import intern, map
 
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import Counter, OrderedDict, defaultdict, namedtuple
 from itertools import product
 
 from gem.node import Memoizer, traversal
@@ -69,9 +69,7 @@ class MonomialSum(object):
         assert len(sum_indices) == len(sum_indices_set)
 
         atomics = tuple(atomics)
-        atomics_set = frozenset(atomics)
-        if len(atomics) != len(atomics_set):
-            raise NotImplementedError("MonomialSum does not support duplicate atomics")
+        atomics_set = frozenset(iteritems(Counter(atomics)))
 
         assert isinstance(rest, Node)
 

--- a/gem/refactorise.py
+++ b/gem/refactorise.py
@@ -1,0 +1,234 @@
+"""Data structures and algorithms for generic expansion and
+refactorisation."""
+
+from __future__ import absolute_import, print_function, division
+from six import iteritems
+from six.moves import intern, map
+
+from collections import OrderedDict, defaultdict, namedtuple
+from itertools import product
+
+from gem.node import Memoizer, traversal
+from gem.gem import Node, Zero, Product, Sum, Indexed, ListTensor, one
+from gem.optimise import (remove_componenttensors, sum_factorise,
+                          traverse_product, traverse_sum, unroll_indexsum)
+
+
+# Refactorisation labels
+
+ATOMIC = intern('atomic')
+"""Label: the expression need not be broken up into smaller parts"""
+
+COMPOUND = intern('compound')
+"""Label: the expression must be broken up into smaller parts"""
+
+OTHER = intern('other')
+"""Label: the expression is irrelevant with regards to refactorisation"""
+
+
+Monomial = namedtuple('Monomial', ['sum_indices', 'atomics', 'rest'])
+"""Monomial type, representation of a tensor product with some
+distinguished factors (called atomics).
+
+- sum_indices: indices to sum over
+- atomics: tuple of expressions classified as ATOMIC
+- rest: a single expression classified as OTHER
+
+A :py:class:`Monomial` is a structured description of the expression:
+
+.. code-block:: python
+
+    IndexSum(reduce(Product, atomics, rest), sum_indices)
+
+"""
+
+
+class MonomialSum(object):
+    """Represents a sum of :py:class:`Monomial`s.
+
+    The set of :py:class:`Monomial` summands are represented as a
+    mapping from a pair of unordered ``sum_indices`` and unordered
+    ``atomics`` to a ``rest`` GEM expression.  This representation
+    makes it easier to merge similar monomials.
+    """
+    def __init__(self):
+        # (unordered sum_indices, unordered atomics) -> rest
+        self.monomials = defaultdict(Zero)
+
+        # We shall retain ordering for deterministic code generation:
+        #
+        # (unordered sum_indices, unordered atomics) ->
+        #     (ordered sum_indices, ordered atomics)
+        self.ordering = OrderedDict()
+
+    def add(self, sum_indices, atomics, rest):
+        """Updates the :py:class:`MonomialSum` adding a new monomial."""
+        sum_indices = tuple(sum_indices)
+        sum_indices_set = frozenset(sum_indices)
+        # Sum indices cannot have duplicates
+        assert len(sum_indices) == len(sum_indices_set)
+
+        atomics = tuple(atomics)
+        atomics_set = frozenset(atomics)
+        if len(atomics) != len(atomics_set):
+            raise NotImplementedError("MonomialSum does not support duplicate atomics")
+
+        assert isinstance(rest, Node)
+
+        key = (sum_indices_set, atomics_set)
+        self.monomials[key] = Sum(self.monomials[key], rest)
+        self.ordering.setdefault(key, (sum_indices, atomics))
+
+    def __iter__(self):
+        """Iteration yields :py:class:`Monomial` objects"""
+        for key, (sum_indices, atomics) in iteritems(self.ordering):
+            rest = self.monomials[key]
+            yield Monomial(sum_indices, atomics, rest)
+
+    @staticmethod
+    def sum(*args):
+        """Sum of multiple :py:class:`MonomialSum`s"""
+        result = MonomialSum()
+        for arg in args:
+            assert isinstance(arg, MonomialSum)
+            # Optimised implementation: no need to decompose and
+            # reconstruct key.
+            for key, rest in iteritems(arg.monomials):
+                result.monomials[key] = Sum(result.monomials[key], rest)
+            for key, value in iteritems(arg.ordering):
+                result.ordering.setdefault(key, value)
+        return result
+
+    @staticmethod
+    def product(*args):
+        """Product of multiple :py:class:`MonomialSum`s"""
+        result = MonomialSum()
+        for monomials in product(*args):
+            sum_indices = []
+            atomics = []
+            rest = one
+            for s, a, r in monomials:
+                sum_indices.extend(s)
+                atomics.extend(a)
+                rest = Product(r, rest)
+            result.add(sum_indices, atomics, rest)
+        return result
+
+
+class FactorisationError(Exception):
+    """Raised when factorisation fails to achieve some desired form."""
+    pass
+
+
+def _collect_monomials(expression, self):
+    """Refactorises an expression into a sum-of-products form, using
+    distributivity rules (i.e. a*(b + c) -> a*b + a*c).  Expansion
+    proceeds until all "compound" expressions are broken up.
+
+    :arg expression: a GEM expression to refactorise
+    :arg self: function for recursive calls
+
+    :returns: :py:class:`MonomialSum`
+
+    :raises FactorisationError: Failed to break up some "compound"
+                                expressions with expansion.
+    """
+    # Phase 1: Collect and categorise product terms
+    def stop_at(expr):
+        # Break up compounds only
+        return self.classifier(expr) != COMPOUND
+    common_indices, terms = traverse_product(expression, stop_at=stop_at)
+    common_indices = tuple(common_indices)
+
+    common_atomics = []
+    common_others = []
+    compounds = []
+    for term in terms:
+        cls = self.classifier(term)
+        if cls == ATOMIC:
+            common_atomics.append(term)
+        elif cls == COMPOUND:
+            compounds.append(term)
+        elif cls == OTHER:
+            common_others.append(term)
+        else:
+            raise ValueError("Classifier returned illegal value.")
+    common_atomics = tuple(common_atomics)
+
+    # Phase 2: Attempt to break up compound terms into summands
+    sums = []
+    for expr in compounds:
+        summands = traverse_sum(expr, stop_at=stop_at)
+        if len(summands) <= 1:
+            # Compound term is not an addition, avoid infinite
+            # recursion and fail gracefully raising an exception.
+            raise FactorisationError(expr)
+        # Recurse into each summand, concatenate their results
+        sums.append(MonomialSum.sum(*map(self, summands)))
+
+    # Phase 3: Expansion
+    #
+    # Each element of ``sums`` is a MonomialSum.  Expansion produces a
+    # series (representing a sum) of products of monomials.
+    result = MonomialSum()
+    for s, a, r in MonomialSum.product(*sums):
+        all_indices = common_indices + s
+        atomics = common_atomics + a
+
+        # All free indices that appear in atomic terms
+        atomic_indices = set().union(*[atomic.free_indices
+                                       for atomic in atomics])
+
+        # Sum indices that appear in atomic terms
+        # (will go to the result :py:class:`Monomial`)
+        sum_indices = tuple(index for index in all_indices
+                            if index in atomic_indices)
+
+        # Sum indices that do not appear in atomic terms
+        # (can factorise them over atomic terms immediately)
+        rest_indices = tuple(index for index in all_indices
+                             if index not in atomic_indices)
+
+        # Not really sum factorisation, but rather just an optimised
+        # way of building a product.
+        rest = sum_factorise(rest_indices, common_others + [r])
+
+        result.add(sum_indices, atomics, rest)
+    return result
+
+
+def collect_monomials(expressions, classifier):
+    """Refactorises expressions into a sum-of-products form, using
+    distributivity rules (i.e. a*(b + c) -> a*b + a*c).  Expansion
+    proceeds until all "compound" expressions are broken up.
+
+    :arg expressions: GEM expressions to refactorise
+    :arg classifier: a function that can classify any GEM expression
+                     as ``ATOMIC``, ``COMPOUND``, or ``OTHER``.  This
+                     classification drives the factorisation.
+
+    :returns: list of :py:class:`MonomialSum`s
+
+    :raises FactorisationError: Failed to break up some "compound"
+                                expressions with expansion.
+    """
+    # Get ComponentTensors out of the way
+    expressions = remove_componenttensors(expressions)
+
+    # Get ListTensors out of the way
+    must_unroll = []  # indices to unroll
+    for node in traversal(expressions):
+        if isinstance(node, Indexed):
+            child, = node.children
+            if isinstance(child, ListTensor) and classifier(node) == COMPOUND:
+                must_unroll.extend(node.multiindex)
+    if must_unroll:
+        must_unroll = set(must_unroll)
+        expressions = unroll_indexsum(expressions,
+                                      predicate=lambda i: i in must_unroll)
+        expressions = remove_componenttensors(expressions)
+
+    # Finally, refactorise expressions
+    mapper = Memoizer(_collect_monomials)
+    mapper.classifier = classifier
+    return list(map(mapper, expressions))

--- a/tests/test_refactorise.py
+++ b/tests/test_refactorise.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import, print_function, division
+
+from functools import partial
+
+import pytest
+
+import gem
+from gem.node import traversal
+from gem.refactorise import ATOMIC, COMPOUND, OTHER, Monomial, collect_monomials
+
+
+def test_refactorise():
+    f = gem.Variable('f', (3,))
+    u = gem.Variable('u', (3,))
+    v = gem.Variable('v', ())
+
+    i = gem.Index()
+    f_i = gem.Indexed(f, (i,))
+    u_i = gem.Indexed(u, (i,))
+
+    def classify(atomics_set, expression):
+        if expression in atomics_set:
+            return ATOMIC
+
+        for node in traversal([expression]):
+            if node in atomics_set:
+                return COMPOUND
+
+        return OTHER
+    classifier = partial(classify, {u_i, v})
+
+    # \sum_i 5*(2*u_i + -1*v)*(u_i + v*f)
+    expr = gem.IndexSum(
+        gem.Product(
+            gem.Literal(5),
+            gem.Product(
+                gem.Sum(gem.Product(gem.Literal(2), u_i),
+                        gem.Product(gem.Literal(-1), v)),
+                gem.Sum(u_i, gem.Product(v, f_i))
+            )
+        ),
+        (i,)
+    )
+
+    expected = [
+        Monomial((i,),
+                 (u_i, u_i),
+                 gem.Literal(10)),
+        Monomial((i,),
+                 (u_i, v),
+                 gem.Product(gem.Literal(5),
+                             gem.Sum(gem.Product(f_i, gem.Literal(2)),
+                                     gem.Literal(-1)))),
+        Monomial((),
+                 (v, v),
+                 gem.Product(gem.Literal(5),
+                             gem.IndexSum(gem.Product(f_i, gem.Literal(-1)),
+                                          (i,)))),
+    ]
+
+    actual, = collect_monomials([expr], classifier)
+    assert expected == list(actual)
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])


### PR DESCRIPTION
This is the common part of two feature branches:

- `argument-sketch`: applies argument factorisation and sum factorisation for arguments at the GEM level, rather than leaving it for COFFEE.
- `tensor`: Similar to the tensor representation of FFC, attempts to rearrange the GEM expression such that the quadrature loop is constant folded at compile time.

Refactorisation is parametrized by a _classifier_ function which classifies any GEM subexpression as

- `atomic`: an expression of particular interest that needs no further decomposition
- `compound`: an expression "containing" multiple atomics, application of distributivity rules (expansion) is necessary
- `other`: an expression of no particular interest for refactorisation

For example, for argument factorisation atomics have exactly one argument index as free index, compounds have more than one, and others have no argument indices. For the "tensor representation" atomics are literal tables with a quadrature index, compounds are quadrature index-dependent expressions, and others have no dependency on any quadrature index.

Additionally, this pull request optimises associativity during sum factorisation.

Includes a small test case.