### PR TITLE
Mode infrastructure and multiple little changes

### DIFF
--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -34,10 +34,12 @@ class NoopError(Exception):
     pass
 
 
-def preprocess_gem(expressions):
+def preprocess_gem(expressions, replace_delta=True, remove_componenttensors=True):
     """Lower GEM nodes that cannot be translated to C directly."""
-    expressions = optimise.replace_delta(expressions)
-    expressions = optimise.remove_componenttensors(expressions)
+    if replace_delta:
+        expressions = optimise.replace_delta(expressions)
+    if remove_componenttensors:
+        expressions = optimise.remove_componenttensors(expressions)
     return expressions
 
 

--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -7,7 +7,7 @@ C code or a COFFEE AST.
 """
 
 from __future__ import absolute_import, print_function, division
-from six.moves import zip
+from six.moves import filter
 
 import collections
 import itertools
@@ -41,23 +41,22 @@ def preprocess_gem(expressions):
     return expressions
 
 
-def compile_gem(return_variables, expressions, prefix_ordering, remove_zeros=False):
+def compile_gem(assignments, prefix_ordering, remove_zeros=False):
     """Compiles GEM to Impero.
 
-    :arg return_variables: return variables for each root (type: GEM expressions)
-    :arg expressions: multi-root expression DAG (type: GEM expressions)
+    :arg assignments: list of (return variable, expression DAG root) pairs
     :arg prefix_ordering: outermost loop indices
     :arg remove_zeros: remove zero assignment to return variables
     """
     # Remove zeros
     if remove_zeros:
-        rv = []
-        es = []
-        for var, expr in zip(return_variables, expressions):
-            if not isinstance(expr, gem.Zero):
-                rv.append(var)
-                es.append(expr)
-        return_variables, expressions = rv, es
+        def nonzero(assignment):
+            variable, expression = assignment
+            return not isinstance(expression, gem.Zero)
+        assignments = list(filter(nonzero, assignments))
+
+    # Just the expressions
+    expressions = [expression for variable, expression in assignments]
 
     # Collect indices in a deterministic order
     indices = OrderedSet()
@@ -79,7 +78,7 @@ def compile_gem(return_variables, expressions, prefix_ordering, remove_zeros=Fal
     get_indices = lambda expr: apply_ordering(expr.free_indices)
 
     # Build operation ordering
-    ops = scheduling.emit_operations(list(zip(return_variables, expressions)), get_indices)
+    ops = scheduling.emit_operations(assignments, get_indices)
 
     # Empty kernel
     if len(ops) == 0:

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -20,7 +20,7 @@ def test_loop_fusion():
     e2 = make_expression(i, i)
 
     def gencode(expr):
-        impero_c = impero_utils.compile_gem([Ri], [expr], (i, j))
+        impero_c = impero_utils.compile_gem([(Ri, expr)], (i, j))
         return impero_c.tree
 
     assert len(gencode(e1).children) == len(gencode(e2).children)

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, division
 from six.moves import range
 
-import collections
 import time
 from functools import reduce
 from itertools import chain
@@ -106,12 +105,10 @@ def compile_integral(integral_data, form_data, prefix, parameters,
 
     builder.set_coefficients(integral_data, form_data)
 
-    # Map from UFL FiniteElement objects to Index instances.  This is
+    # Map from UFL FiniteElement objects to multiindices.  This is
     # so we reuse Index instances when evaluating the same coefficient
-    # multiple times with the same table.  Occurs, for example, if we
-    # have multiple integrals here (and the affine coordinate
-    # evaluation can be hoisted).
-    index_cache = collections.defaultdict(gem.Index)
+    # multiple times with the same table.
+    index_cache = {}
 
     kernel_cfg = dict(interface=builder,
                       ufl_cell=cell,

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, print_function, division
-from six.moves import range
+from six.moves import range, zip
 
 import time
 from functools import reduce
@@ -171,7 +171,8 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     if builder.needs_cell_orientations(ir):
         builder.require_cell_orientations()
 
-    impero_c = impero_utils.compile_gem(return_variables, ir,
+    assignments = list(zip(return_variables, ir))
+    impero_c = impero_utils.compile_gem(assignments,
                                         tuple(quadrature_indices) + argument_indices,
                                         remove_zeros=True)
 
@@ -301,7 +302,7 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
     return_arg = ast.Decl(SCALAR_TYPE, ast.Symbol('A', rank=return_shape))
     return_expr = gem.Indexed(return_var, return_indices)
     ir, = impero_utils.preprocess_gem([ir])
-    impero_c = impero_utils.compile_gem([return_expr], [ir], return_indices)
+    impero_c = impero_utils.compile_gem([(return_expr, ir)], return_indices)
     point_index, = point_set.indices
     body = generate_coffee(impero_c, {point_index: 'p'}, parameters["precision"])
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -123,13 +123,10 @@ def compile_integral(integral_data, form_data, prefix, parameters,
 
     mode_irs = collections.OrderedDict()
     for integral in integral_data.integrals:
-        params = {}
-        # Record per-integral parameters
-        params.update(integral.metadata())
+        params = parameters.copy()
+        params.update(integral.metadata())  # integral metadata overrides
         if params.get("quadrature_rule") == "default":
             del params["quadrature_rule"]
-        # parameters override per-integral metadata
-        params.update(parameters)
 
         mode = pick_mode(params["mode"])
         mode_irs.setdefault(mode, collections.OrderedDict())
@@ -160,7 +157,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
                                       interior_facet=interior_facet,
                                       **config)
         reps = mode.Integrals(expressions, quadrature_multiindex,
-                              argument_multiindices, parameters)
+                              argument_multiindices, params)
         for var, rep in zip(return_variables, reps):
             mode_irs[mode].setdefault(var, []).append(rep)
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, print_function, division
-from six import iteritems, viewitems
+from six import iterkeys, iteritems, viewitems
 from six.moves import range, zip
 
 import collections
+import operator
 import time
+from functools import reduce
 from itertools import chain
 
 from ufl.algorithms import extract_arguments, extract_coefficients
@@ -173,7 +175,10 @@ def compile_integral(integral_data, form_data, prefix, parameters,
         expressions = []
 
     # Need optimised roots for COFFEE
-    expressions = impero_utils.preprocess_gem(expressions)
+    options = dict(reduce(operator.and_,
+                          [viewitems(mode.finalise_options)
+                           for mode in iterkeys(mode_irs)]))
+    expressions = impero_utils.preprocess_gem(expressions, **options)
 
     # Look for cell orientations in the IR
     if builder.needs_cell_orientations(expressions):

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -111,7 +111,7 @@ class Context(ProxyKernelInterface):
 
     @cached_property
     def index_cache(self):
-        return collections.defaultdict(gem.Index)
+        return {}
 
 
 class Translator(MultiFunction, ModifiedTerminalMixin, ufl2gem.Mixin):
@@ -340,7 +340,8 @@ def translate_coefficient(terminal, mt, ctx):
                           for alpha, tables in iteritems(per_derivative)}
 
     # Coefficient evaluation
-    beta = element.get_indices()
+    ctx.index_cache.setdefault(terminal.ufl_element(), element.get_indices())
+    beta = ctx.index_cache[terminal.ufl_element()]
     zeta = element.get_value_indices()
     value_dict = {}
     for alpha, table in iteritems(per_derivative):

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -165,15 +165,15 @@ class KernelBuilder(KernelBuilderBase):
         elif integral_type == 'interior_facet_horiz':
             self._facet_number = {'+': 1, '-': 0}
 
-    def set_arguments(self, arguments, indices):
+    def set_arguments(self, arguments, multiindices):
         """Process arguments.
 
         :arg arguments: :class:`ufl.Argument`s
-        :arg indices: GEM argument indices
+        :arg multiindices: GEM argument multiindices
         :returns: GEM expression representing the return variable
         """
         self.local_tensor, expressions = prepare_arguments(
-            arguments, indices, interior_facet=self.interior_facet)
+            arguments, multiindices, interior_facet=self.interior_facet)
         return expressions
 
     def set_coordinates(self, coefficient):

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -45,15 +45,15 @@ class KernelBuilder(KernelBuilderBase):
                 '-': gem.VariableIndex(gem.Variable("facet_1", ()))
             }
 
-    def set_arguments(self, arguments, indices):
+    def set_arguments(self, arguments, multiindices):
         """Process arguments.
 
         :arg arguments: :class:`ufl.Argument`s
-        :arg indices: GEM argument indices
+        :arg multiindices: GEM argument multiindices
         :returns: GEM expression representing the return variable
         """
         self.local_tensor, prepare, expressions = prepare_arguments(
-            arguments, indices, interior_facet=self.interior_facet)
+            arguments, multiindices, interior_facet=self.interior_facet)
         self.apply_glue(prepare)
         return expressions
 

--- a/tsfc/parameters.py
+++ b/tsfc/parameters.py
@@ -13,6 +13,7 @@ PARAMETERS = {
     "quadrature_rule": "auto",
     "quadrature_degree": "auto",
 
+    # Default mode
     "mode": "vanilla",
 
     # Maximum extent to unroll index sums. Default is 3, so that loops

--- a/tsfc/parameters.py
+++ b/tsfc/parameters.py
@@ -13,6 +13,8 @@ PARAMETERS = {
     "quadrature_rule": "auto",
     "quadrature_degree": "auto",
 
+    "mode": "vanilla",
+
     # Maximum extent to unroll index sums. Default is 3, so that loops
     # over geometric dimensions are unrolled; this improves assembly
     # performance.  Can be disabled by setting it to None, False or 0;

--- a/tsfc/vanilla.py
+++ b/tsfc/vanilla.py
@@ -39,3 +39,8 @@ def flatten(var_reps):
         expressions = reps  # representations are expressions
         for expression in expressions:
             yield (variable, expression)
+
+
+finalise_options = {}
+"""To avoid duplicate work, these options that are safe to pass to
+:py:func:`gem.impero_utils.preprocess_gem`."""

--- a/tsfc/vanilla.py
+++ b/tsfc/vanilla.py
@@ -5,16 +5,37 @@ from gem.optimise import unroll_indexsum
 
 
 def Integrals(expressions, quadrature_multiindex, argument_multiindices, parameters):
+    """Constructs an integral representation for each GEM integrand
+    expression.
+
+    :arg expressions: integrand multiplied with quadrature weight;
+                      multi-root GEM expression DAG
+    :arg quadrature_multiindex: quadrature multiindex (tuple)
+    :arg argument_multiindices: tuple of argument multiindices,
+                                one multiindex for each argument
+    :arg parameters: parameters dictionary
+
+    :returns: list of integral representations
+    """
+    # Unroll
     max_extent = parameters["unroll_indexsum"]
     if max_extent:
         def predicate(index):
             return index.extent <= max_extent
         expressions = unroll_indexsum(expressions, predicate=predicate)
+    # Integral representation: just a GEM expression
     return [index_sum(e, quadrature_multiindex) for e in expressions]
 
 
 def flatten(var_reps):
+    """Flatten mode-specific intermediate representation to a series of
+    assignments.
+
+    :arg var_reps: series of (return variable, [integral representation]) pairs
+
+    :returns: series of (return variable, GEM expression root) pairs
+    """
     for variable, reps in var_reps:
-        expressions = reps
+        expressions = reps  # representations are expressions
         for expression in expressions:
             yield (variable, expression)

--- a/tsfc/vanilla.py
+++ b/tsfc/vanilla.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, print_function, division
+from six import iteritems
+
+from gem import index_sum
+from gem.optimise import unroll_indexsum
+
+
+def integrate(expressions, quadrature_multiindex, parameters):
+    max_extent = parameters["unroll_indexsum"]
+    if max_extent:
+        def predicate(index):
+            return index.extent <= max_extent
+        expressions = unroll_indexsum(expressions, predicate=predicate)
+    return [index_sum(e, quadrature_multiindex) for e in expressions]
+
+
+def aggregate(rep_dict):
+    for variable, reps in iteritems(rep_dict):
+        expressions = reps
+        for expression in expressions:
+            yield (variable, expression)

--- a/tsfc/vanilla.py
+++ b/tsfc/vanilla.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import, print_function, division
-from six import iteritems
 
 from gem import index_sum
 from gem.optimise import unroll_indexsum
 
 
-def integrate(expressions, quadrature_multiindex, parameters):
+def Integrals(expressions, quadrature_multiindex, argument_multiindices, parameters):
     max_extent = parameters["unroll_indexsum"]
     if max_extent:
         def predicate(index):
@@ -14,8 +13,8 @@ def integrate(expressions, quadrature_multiindex, parameters):
     return [index_sum(e, quadrature_multiindex) for e in expressions]
 
 
-def aggregate(rep_dict):
-    for variable, reps in iteritems(rep_dict):
+def flatten(var_reps):
+    for variable, reps in var_reps:
         expressions = reps
         for expression in expressions:
             yield (variable, expression)


### PR DESCRIPTION
This is really a bag of changes, so I discuss them one by one:

- Renames: `argument_indices` -> `argument_multiindices` and `flat_argument_indices` -> `argument_indices`. This should have happened during the FInAT transition, but it did not, so better later than never. @tj-sun: you are using and propagating the old names, please understand the changes and update your branch accordingly.
- Index cache: another loss of the FInAT transition. On current master, the index cache exists in bits and pieces but it is never actually used. This change puts the index cache back into use.
- Internal API of `gem.impero_utils.compile_gem` changes.
- Per discussion with @blechta, per-integral metadata now has precedence over the `parameters=` keyword argument provided to `compile_form`/`compile_integral` (and also over the defaults). This will now match FFC's behaviour. @wence-: We miss this early history, but I think that the current master behaviour was your choice. Any particular reason? Everything still seems to pass with this change.
- Some basic infrastructure is set up for modes, more details below.

### What are modes?

Modes are different ways of transforming the GEM expressions that are the intermediate representation of TSFC. In some way, they are similar to representations in FFC. However, in FFC each representation is a distinct UFL -> C++ pipeline, while in TSFC there is a single UFL -> GEM pipeline and a single GEM -> COFFEE AST -> C pipeline, and modes are GEM -> GEM transformers that are inserted in the middle.

### Why do we need them?

The golden age of "just use COFFEE" is over. While current master relies on COFFEE for sum factorisation of arguments, it demonstrably fails to get the optimal algorithmic complexity on bilinear forms. This fuels the need to maintain the `argument-sketch` branch, yet that functionality is kept off master because it is on a branch. In addition, @tj-sun is working on porting the expression optimisations of COFFEE to GEM, so we will need a switch to turn his code on and off.

### What modes are expected in the near future?

- `vanilla`: This PR names the behaviour of current master *vanilla* mode: ["simplest version of something, without any optional extras, basic or ordinary."](https://en.wikipedia.org/wiki/Plain_vanilla)
- `coffee`: @tj-sun's work may be wired in as *coffee* mode.
- `spectral`: My `argument-sketch` branch could be brought into master for reliable sum factorisation, for @alsgregory (firedrakeproject/firedrake#972), and for further research on delta elimination in arguments.
- `tensor`: Based on the `tensor` branch which I made as a toy exercise in the winter break. Similar in spirit to the tensor representation of FFC, but rather than trying to reduce the whole expression to a single contraction between a reference tensor and a geometry tensor, it simply eliminates all quadrature loops by applying the contractions at compile time. The main difference is that the expression can be arbitrarily complex in quantities that are cell-wise constant, because this mode does not munge with those subexpressions, while the tensor representation would simply fail. (In particular, the `tensor` branch only fails 5 additional demos in the FFC regression test suite.)

All names are, of course, subject to discussion.

### Why are these modes not called representations like in FFC?

1. They are different under the hood, see "What are modes?" above.
2. So that they may be used from FFC. For example, compiling `u*v*dx(metadata={'representation': 'tensor'})` with FFC uses the FFC's tensor representation, while `u*v*dx(metadata={'representation': 'tsfc', 'mode': 'tensor'})` would use TSFC's tensor mode.