### PR TITLE
Spectral mode

### DIFF
--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -226,8 +226,7 @@ def delta_elimination(sum_indices, factors):
                        for f in factors if isinstance(f, Delta)
                        for index in (f.i, f.j) if index in sum_indices]
 
-    # Drop ones
-    return sum_indices, [e for e in factors if e != one]
+    return sum_indices, factors
 
 
 def associate_product(factors):

--- a/tests/test_firedrake_972.py
+++ b/tests/test_firedrake_972.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, print_function, division
+import numpy
+import pytest
+
+from coffee.visitors import EstimateFlops
+
+from ufl import (Mesh, FunctionSpace, VectorElement, TensorElement,
+                 Coefficient, TestFunction, interval, indices, dx)
+from ufl.classes import IndexSum, Product, MultiIndex
+
+from tsfc import compile_form
+
+
+def count_flops(n):
+    mesh = Mesh(VectorElement('CG', interval, 1))
+    tfs = FunctionSpace(mesh, TensorElement('DG', interval, 1, shape=(n, n)))
+    vfs = FunctionSpace(mesh, VectorElement('DG', interval, 1, dim=n))
+
+    ensemble_f = Coefficient(vfs)
+    ensemble2_f = Coefficient(vfs)
+    phi = TestFunction(tfs)
+
+    i, j = indices(2)
+    nc = 42  # magic number
+    L = ((IndexSum(IndexSum(Product(nc * phi[i, j], Product(ensemble_f[i], ensemble_f[i])),
+                            MultiIndex((i,))), MultiIndex((j,))) * dx) +
+         (IndexSum(IndexSum(Product(nc * phi[i, j], Product(ensemble2_f[j], ensemble2_f[j])),
+                            MultiIndex((i,))), MultiIndex((j,))) * dx) -
+         (IndexSum(IndexSum(2 * nc * Product(phi[i, j], Product(ensemble_f[i], ensemble2_f[j])),
+                            MultiIndex((i,))), MultiIndex((j,))) * dx))
+
+    kernel, = compile_form(L, parameters=dict(mode='spectral'))
+    return EstimateFlops().visit(kernel.ast)
+
+
+def test_convergence():
+    ns = [10, 20, 40, 80, 100]
+    flops = [count_flops(n) for n in ns]
+    rates = numpy.diff(numpy.log(flops)) / numpy.diff(numpy.log(ns))
+    assert (rates < 2).all()  # only quadratic operation count, not more
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])

--- a/tests/test_sum_factorisation.py
+++ b/tests/test_sum_factorisation.py
@@ -3,6 +3,7 @@ from six.moves import range
 
 import numpy
 import pytest
+import sys
 
 from coffee.visitors import EstimateFlops
 
@@ -26,6 +27,8 @@ def count_flops(form):
     return EstimateFlops().visit(kernel.ast)
 
 
+@pytest.mark.skipif(sys.version_info >= (3,),
+                    reason="Tuple degrees break UFL in Python3")
 @pytest.mark.parametrize(('cell', 'order'),
                          [(quadrilateral, 5),
                           (TensorProductCell(interval, interval), 5),
@@ -41,6 +44,8 @@ def test_lhs(cell, order):
     assert (rates < order).all()
 
 
+@pytest.mark.skipif(sys.version_info >= (3,),
+                    reason="Tuple degrees break UFL in Python3")
 @pytest.mark.parametrize(('cell', 'order'),
                          [(quadrilateral, 3),
                           (TensorProductCell(interval, interval), 3),

--- a/tests/test_sum_factorisation.py
+++ b/tests/test_sum_factorisation.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import, print_function, division
+from six.moves import range
+
+import numpy
+import pytest
+
+from coffee.visitors import EstimateFlops
+
+from ufl import (Mesh, FunctionSpace, FiniteElement, VectorElement,
+                 TestFunction, TrialFunction, TensorProductCell, dx,
+                 action, interval, triangle, quadrilateral, dot, grad)
+
+from tsfc import compile_form
+
+
+def helmholtz(cell, degree):
+    m = Mesh(VectorElement('CG', cell, 1))
+    V = FunctionSpace(m, FiniteElement('CG', cell, degree))
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    return (u*v + dot(grad(u), grad(v)))*dx
+
+
+def count_flops(form):
+    kernel, = compile_form(form, parameters=dict(mode='spectral'))
+    return EstimateFlops().visit(kernel.ast)
+
+
+@pytest.mark.parametrize(('cell', 'order'),
+                         [(quadrilateral, 5),
+                          (TensorProductCell(interval, interval), 5),
+                          (TensorProductCell(triangle, interval), 7),
+                          (TensorProductCell(quadrilateral, interval), 7)])
+def test_lhs(cell, order):
+    degrees = list(range(3, 8))
+    if cell == TensorProductCell(triangle, interval):
+        degrees = list(range(3, 6))
+    flops = [count_flops(helmholtz(cell, degree))
+             for degree in degrees]
+    rates = numpy.diff(numpy.log(flops)) / numpy.diff(numpy.log(degrees))
+    assert (rates < order).all()
+
+
+@pytest.mark.parametrize(('cell', 'order'),
+                         [(quadrilateral, 3),
+                          (TensorProductCell(interval, interval), 3),
+                          (TensorProductCell(triangle, interval), 5),
+                          (TensorProductCell(quadrilateral, interval), 4)])
+def test_rhs(cell, order):
+    degrees = list(range(3, 8))
+    if cell == TensorProductCell(triangle, interval):
+        degrees = list(range(3, 6))
+    flops = [count_flops(action(helmholtz(cell, degree)))
+             for degree in degrees]
+    rates = numpy.diff(numpy.log(flops)) / numpy.diff(numpy.log(degrees))
+    assert (rates < order).all()
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -365,6 +365,8 @@ def pick_mode(mode):
     "Return one of the specialized optimisation modules from a mode string."
     if mode == "vanilla":
         import tsfc.vanilla as m
+    elif mode == "spectral":
+        import tsfc.spectral as m
     else:
         raise ValueError("Unknown mode: {}".format(mode))
     return m

--- a/tsfc/spectral.py
+++ b/tsfc/spectral.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import, print_function, division
+from six.moves import map, zip
+
+from functools import partial
+from itertools import chain
+
+from gem import index_sum
+from gem.optimise import delta_elimination, sum_factorise as _sum_factorise, unroll_indexsum
+from gem.refactorise import ATOMIC, COMPOUND, OTHER, collect_monomials
+
+
+def sum_factorise(sum_indices, factors):
+    sum_indices = list(sum_indices)
+    sum_indices.reverse()
+    return _sum_factorise(*delta_elimination(sum_indices, factors))
+
+
+def Integrals(expressions, quadrature_multiindex, argument_multiindices, parameters):
+    max_extent = parameters["unroll_indexsum"]
+    if max_extent:
+        def predicate(index):
+            return index.extent <= max_extent
+        expressions = unroll_indexsum(expressions, predicate=predicate)
+    argument_indices = set(chain(*argument_multiindices))
+    return [(argument_indices,
+             index_sum(e, quadrature_multiindex))
+            for e in expressions]
+
+
+def flatten(var_reps):
+    def classify(argument_indices, expression):
+        n = len(argument_indices.intersection(expression.free_indices))
+        if n == 0:
+            return OTHER
+        elif n == 1:
+            return ATOMIC
+        else:
+            return COMPOUND
+
+    for variable, reps in var_reps:
+        argument_indicez, expressions = zip(*reps)
+        argument_indices, = set(map(frozenset, argument_indicez))
+        classifier = partial(classify, argument_indices)
+        for monomial_sum in collect_monomials(expressions, classifier):
+            for sum_indices, args, rest in monomial_sum:
+                yield (variable, sum_factorise(sum_indices, args + (rest,)))
+
+
+finalise_options = {}

--- a/tsfc/spectral.py
+++ b/tsfc/spectral.py
@@ -12,14 +12,18 @@ from gem.refactorise import ATOMIC, COMPOUND, OTHER, MonomialSum, collect_monomi
 
 
 def delta_elimination(sum_indices, args, rest):
-    factors = [rest] + list(args)
+    """IndexSum-Delta cancellation for monomials."""
+    factors = [rest] + list(args)  # construct factors
     sum_indices, factors = _delta_elimination(sum_indices, factors)
+    # Destructure factors after cancellation
     rest = factors.pop(0)
     args = factors
     return sum_indices, args, rest
 
 
 def sum_factorise(sum_indices, args, rest):
+    """Optimised monomial product construction through sum factorisation
+    with reversed sum indices."""
     sum_indices = list(sum_indices)
     sum_indices.reverse()
     factors = args + (rest,)
@@ -27,11 +31,14 @@ def sum_factorise(sum_indices, args, rest):
 
 
 def Integrals(expressions, quadrature_multiindex, argument_multiindices, parameters):
+    # Unroll
     max_extent = parameters["unroll_indexsum"]
     if max_extent:
         def predicate(index):
             return index.extent <= max_extent
         expressions = unroll_indexsum(expressions, predicate=predicate)
+    # Integral representation: pair with the set of argument indices
+    # and a GEM expression
     argument_indices = set(chain(*argument_multiindices))
     return [(argument_indices,
              index_sum(e, quadrature_multiindex))
@@ -39,6 +46,7 @@ def Integrals(expressions, quadrature_multiindex, argument_multiindices, paramet
 
 
 def flatten(var_reps):
+    # Classifier for argument factorisation
     def classify(argument_indices, expression):
         n = len(argument_indices.intersection(expression.free_indices))
         if n == 0:
@@ -49,14 +57,19 @@ def flatten(var_reps):
             return COMPOUND
 
     for variable, reps in var_reps:
+        # Destructure representation
         argument_indicez, expressions = zip(*reps)
+        # Assert identical argument indices for all integrals
         argument_indices, = set(map(frozenset, argument_indicez))
+        # Argument factorise
         classifier = partial(classify, argument_indices)
         for monomial_sum in collect_monomials(expressions, classifier):
+            # Compact MonomialSum after IndexSum-Delta cancellation
             delta_simplified = MonomialSum()
             for monomial in monomial_sum:
                 delta_simplified.add(*delta_elimination(*monomial))
 
+            # Yield assignments
             for monomial in delta_simplified:
                 yield (variable, sum_factorise(*monomial))
 


### PR DESCRIPTION
Unconditionally argument factorises and applies sum factorisation for argument evaluation. **Not compatible with COFFEE.** Default mode remains `vanilla`.

Advantages:
- Correct algorithmic complexity for sum factorisation, protected by tests.
- @alsgregory used this branch because of firedrakeproject/firedrake#972. After merging this, he will have access to good behaviour on master with the form compiler option `{'mode': 'spectral'}`.

This is still work in progress, but it will not hurt because not enabled by default, but it offers an option that delivers the above goods.