### PR TITLE
Improve FEniCS compatibility

### DIFF
--- a/tests/test_create_fiat_element.py
+++ b/tests/test_create_fiat_element.py
@@ -54,7 +54,7 @@ def test_tensor_prod_simple(ufl_A, ufl_B):
     A = create_element(ufl_A)
     B = create_element(ufl_B)
 
-    assert isinstance(tensor, supported_elements[tensor_ufl.family()])
+    assert isinstance(tensor, FIAT.TensorProductElement)
 
     assert tensor.A is A
     assert tensor.B is B

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -339,6 +339,8 @@ def lower_integral_type(fiat_cell, integral_type):
         integration_dim = dim
     elif integral_type in ['exterior_facet', 'interior_facet']:
         integration_dim = dim - 1
+    elif integral_type == 'vertex':
+        integration_dim = 0
     else:
         # Extrusion case
         basedim, extrdim = dim

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -104,7 +104,7 @@ class Context(ProxyKernelInterface):
         if len(self.entity_ids) == 1:
             return callback(self.entity_ids[0])
         else:
-            f = self.facet_number(restriction)
+            f = self.entity_number(restriction)
             return gem.select_expression(list(map(callback, self.entity_ids)), f)
 
     argument_multiindices = ()
@@ -335,7 +335,7 @@ def translate_coefficient(terminal, mt, ctx):
         per_derivative = {alpha: take_singleton(tables)
                           for alpha, tables in iteritems(per_derivative)}
     else:
-        f = ctx.facet_number(mt.restriction)
+        f = ctx.entity_number(mt.restriction)
         per_derivative = {alpha: gem.select_expression(tables, f)
                           for alpha, tables in iteritems(per_derivative)}
 

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, print_function, division
 
 from singledispatch import singledispatch
 from functools import partial
+import types
 import weakref
 
 import FIAT
@@ -175,7 +176,12 @@ def _(element, vector_is_mixed):
     if element.family() == "Quadrature":
         # Sneaky import from FFC
         from ffc.quadratureelement import QuadratureElement
-        return QuadratureElement(element)
+        ffc_element = QuadratureElement(element)
+
+        def tabulate(self, order, points, entity):
+            return QuadratureElement.tabulate(self, order, points)
+        ffc_element.tabulate = types.MethodType(tabulate, ffc_element)
+        return ffc_element
     cell = as_fiat_cell(element.cell())
     lmbda = supported_elements[element.family()]
     if lmbda is None:

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -172,6 +172,10 @@ def _(element, vector_is_mixed):
         # Real element is just DG0
         cell = element.cell()
         return create_element(ufl.FiniteElement("DG", cell, 0), vector_is_mixed)
+    if element.family() == "Quadrature":
+        # Sneaky import from FFC
+        from ffc.quadratureelement import QuadratureElement
+        return QuadratureElement(element)
     cell = as_fiat_cell(element.cell())
     lmbda = supported_elements[element.family()]
     if lmbda is None:

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -44,29 +44,23 @@ supported_elements = {
     # These all map directly to FIAT elements
     "Brezzi-Douglas-Marini": FIAT.BrezziDouglasMarini,
     "Brezzi-Douglas-Fortin-Marini": FIAT.BrezziDouglasFortinMarini,
-    "BrokenElement": FIAT.DiscontinuousElement,
     "Bubble": FIAT.Bubble,
     "Crouzeix-Raviart": FIAT.CrouzeixRaviart,
     "Discontinuous Lagrange": FIAT.DiscontinuousLagrange,
     "Discontinuous Taylor": FIAT.DiscontinuousTaylor,
     "Discontinuous Raviart-Thomas": FIAT.DiscontinuousRaviartThomas,
-    "EnrichedElement": FIAT.EnrichedElement,
     "Gauss-Lobatto-Legendre": FIAT.GaussLobattoLegendre,
     "Gauss-Legendre": FIAT.GaussLegendre,
     "Lagrange": FIAT.Lagrange,
     "Nedelec 1st kind H(curl)": FIAT.Nedelec,
     "Nedelec 2nd kind H(curl)": FIAT.NedelecSecondKind,
-    "TensorProductElement": FIAT.TensorProductElement,
     "Raviart-Thomas": FIAT.RaviartThomas,
     "HDiv Trace": FIAT.HDivTrace,
     "Regge": FIAT.Regge,
     "Hellan-Herrmann-Johnson": FIAT.HellanHerrmannJohnson,
     # These require special treatment below
     "DQ": None,
-    "FacetElement": None,
-    "InteriorElement": None,
     "Q": None,
-    "Real": None,
     "RTCE": None,
     "RTCF": None,
 }
@@ -233,8 +227,7 @@ def _(element, vector_is_mixed):
 
 @convert.register(ufl.BrokenElement) # noqa
 def _(element, vector_is_mixed):
-    return supported_elements[element.family()](create_element(element._element,
-                                                               vector_is_mixed))
+    return FIAT.DiscontinuousElement(create_element(element._element, vector_is_mixed))
 
 
 # Now for the TPE-specific stuff

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -216,6 +216,12 @@ def _(element, vector_is_mixed):
                                   restriction_domain="interior")
 
 
+@convert.register(ufl.RestrictedElement)  # noqa
+def _(element, vector_is_mixed):
+    return FIAT.RestrictedElement(create_element(element.sub_element(), vector_is_mixed),
+                                  restriction_domain=element.restriction_domain())
+
+
 @convert.register(ufl.EnrichedElement)  # noqa
 def _(element, vector_is_mixed):
     if len(element._elements) != 2:

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -92,6 +92,16 @@ def convert(element):
 @convert.register(ufl.FiniteElement)
 def convert_finiteelement(element):
     cell = as_fiat_cell(element.cell())
+    if element.family() == "Quadrature":
+        degree = element.degree()
+        if degree is None:
+            # FEniCS default (ffc/quadratureelement.py:34)
+            degree = 1
+        scheme = element.quadrature_scheme()
+        if scheme is None:
+            # FEniCS default (ffc/quadratureelement.py:35)
+            scheme = "canonical"
+        return finat.QuadratureElement(cell, degree, scheme)
     if element.family() not in supported_elements:
         return fiat_compat(element)
     lmbda = supported_elements.get(element.family())

--- a/tsfc/kernel_interface/__init__.py
+++ b/tsfc/kernel_interface/__init__.py
@@ -20,8 +20,8 @@ class KernelInterface(with_metaclass(ABCMeta)):
         """Cell orientation as a GEM expression."""
 
     @abstractmethod
-    def facet_number(self, restriction):
-        """Facet number as a GEM index."""
+    def entity_number(self, restriction):
+        """Facet or vertex number as a GEM index."""
 
 
 ProxyKernelInterface = make_proxy_class('ProxyKernelInterface', KernelInterface)

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -48,10 +48,10 @@ class KernelBuilderBase(KernelInterface):
                                                gem.Literal(1),
                                                gem.Literal(numpy.nan)))
 
-    def facet_number(self, restriction):
-        """Facet number as a GEM index."""
-        # Assume self._facet_number dict is set up at this point.
-        return self._facet_number[restriction]
+    def entity_number(self, restriction):
+        """Facet or vertex number as a GEM index."""
+        # Assume self._entity_number dict is set up at this point.
+        return self._entity_number[restriction]
 
     def apply_glue(self, prepare=None, finalise=None):
         """Append glue code for operations that are not handled in the

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -155,15 +155,15 @@ class KernelBuilder(KernelBuilderBase):
         # Facet number
         if integral_type in ['exterior_facet', 'exterior_facet_vert']:
             facet = gem.Variable('facet', (1,))
-            self._facet_number = {None: gem.VariableIndex(gem.Indexed(facet, (0,)))}
+            self._entity_number = {None: gem.VariableIndex(gem.Indexed(facet, (0,)))}
         elif integral_type in ['interior_facet', 'interior_facet_vert']:
             facet = gem.Variable('facet', (2,))
-            self._facet_number = {
+            self._entity_number = {
                 '+': gem.VariableIndex(gem.Indexed(facet, (0,))),
                 '-': gem.VariableIndex(gem.Indexed(facet, (1,)))
             }
         elif integral_type == 'interior_facet_horiz':
-            self._facet_number = {'+': 1, '-': 0}
+            self._entity_number = {'+': 1, '-': 0}
 
     def set_arguments(self, arguments, multiindices):
         """Process arguments.

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -44,6 +44,8 @@ class KernelBuilder(KernelBuilderBase):
                 '+': gem.VariableIndex(gem.Variable("facet_0", ())),
                 '-': gem.VariableIndex(gem.Variable("facet_1", ()))
             }
+        elif integral_type == "vertex":
+            self._facet_number = {None: gem.VariableIndex(gem.Variable("vertex", ()))}
 
     def set_arguments(self, arguments, multiindices):
         """Process arguments.
@@ -116,6 +118,8 @@ class KernelBuilder(KernelBuilderBase):
         elif self.integral_type == "interior_facet":
             args.append(coffee.Decl("std::size_t", coffee.Symbol("facet_0")))
             args.append(coffee.Decl("std::size_t", coffee.Symbol("facet_1")))
+        elif self.integral_type == "vertex":
+            args.append(coffee.Decl("std::size_t", coffee.Symbol("vertex")))
 
         # Cell orientation(s)
         if self.interior_facet:

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -38,14 +38,14 @@ class KernelBuilder(KernelBuilderBase):
             self._cell_orientations = (gem.Variable("cell_orientation", ()),)
 
         if integral_type == "exterior_facet":
-            self._facet_number = {None: gem.VariableIndex(gem.Variable("facet", ()))}
+            self._entity_number = {None: gem.VariableIndex(gem.Variable("facet", ()))}
         elif integral_type == "interior_facet":
-            self._facet_number = {
+            self._entity_number = {
                 '+': gem.VariableIndex(gem.Variable("facet_0", ())),
                 '-': gem.VariableIndex(gem.Variable("facet_1", ()))
             }
         elif integral_type == "vertex":
-            self._facet_number = {None: gem.VariableIndex(gem.Variable("vertex", ()))}
+            self._entity_number = {None: gem.VariableIndex(gem.Variable("vertex", ()))}
 
     def set_arguments(self, arguments, multiindices):
         """Process arguments.
@@ -112,7 +112,7 @@ class KernelBuilder(KernelBuilderBase):
         args.extend(self.coefficient_args)
         args.extend(self.coordinates_args)
 
-        # Facet number(s)
+        # Facet and vertex number(s)
         if self.integral_type == "exterior_facet":
             args.append(coffee.Decl("std::size_t", coffee.Symbol("facet")))
         elif self.integral_type == "interior_facet":


### PR DESCRIPTION
Adds:
- Vertex integrals (UFC only)
- Quadrature element (FFC and FInAT)
- Restricted element

@martinal, @dorugeber: what is the difference between `RestrictedElement` vs `FacetElement` and `InteriorElement`? They all map to the same FIAT element, feels like a duplicity in UFL.

Requires FInAT/FInAT#25.