### PR TITLE
Improve FEniCS compatibility

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -286,12 +286,12 @@ class MathFunction(Scalar):
     __slots__ = ('name', 'children')
     __front__ = ('name',)
 
-    def __init__(self, name, argument):
+    def __init__(self, name, *args):
         assert isinstance(name, str)
-        assert not argument.shape
+        assert all(arg.shape == () for arg in args)
 
         self.name = name
-        self.children = argument,
+        self.children = args
 
 
 class MinValue(Scalar):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -48,10 +48,9 @@ def compile_form(form, prefix="form", parameters=None):
     kernels = []
     for integral_data in fd.integral_data:
         start = time.time()
-        try:
-            kernels.append(compile_integral(integral_data, fd, prefix, parameters))
-        except impero_utils.NoopError:
-            pass
+        kernel = compile_integral(integral_data, fd, prefix, parameters)
+        if kernel is not None:
+            kernels.append(kernel)
         logger.info(GREEN % "compile_integral finished in %g seconds.", time.time() - start)
 
     logger.info(GREEN % "TSFC finished in %g seconds.", time.time() - cpu_time)
@@ -179,30 +178,34 @@ def compile_integral(integral_data, form_data, prefix, parameters,
                           [viewitems(mode.finalise_options)
                            for mode in iterkeys(mode_irs)]))
     expressions = impero_utils.preprocess_gem(expressions, **options)
+    assignments = list(zip(return_variables, expressions))
 
     # Look for cell orientations in the IR
     if builder.needs_cell_orientations(expressions):
         builder.require_cell_orientations()
 
-    assignments = list(zip(return_variables, expressions))
-    impero_c = impero_utils.compile_gem(assignments,
-                                        tuple(quadrature_indices) + argument_indices,
-                                        remove_zeros=True)
-
-    # Generate COFFEE
-    index_names = [(si, name + str(n))
-                   for index, name in zip(argument_multiindices, ['j', 'k'])
-                   for n, si in enumerate(index)]
-    if len(quadrature_indices) == 1:
-        index_names.append((quadrature_indices[0], 'ip'))
-    else:
-        for i, quadrature_index in enumerate(quadrature_indices):
-            index_names.append((quadrature_index, 'ip_%d' % i))
-
-    body = generate_coffee(impero_c, index_names, parameters["precision"], expressions, argument_indices)
-
     kernel_name = "%s_%s_integral_%s" % (prefix, integral_type, integral_data.subdomain_id)
-    return builder.construct_kernel(kernel_name, body)
+    try:
+        # Construct ImperoC
+        index_ordering = tuple(quadrature_indices) + argument_indices
+        impero_c = impero_utils.compile_gem(assignments, index_ordering, remove_zeros=True)
+
+        # Generate COFFEE
+        index_names = [(si, name + str(n))
+                       for index, name in zip(argument_multiindices, ['j', 'k'])
+                       for n, si in enumerate(index)]
+        if len(quadrature_indices) == 1:
+            index_names.append((quadrature_indices[0], 'ip'))
+        else:
+            for i, quadrature_index in enumerate(quadrature_indices):
+                index_names.append((quadrature_index, 'ip_%d' % i))
+
+        # Construct kernel
+        body = generate_coffee(impero_c, index_names, parameters["precision"], expressions, argument_indices)
+        return builder.construct_kernel(kernel_name, body)
+    except impero_utils.NoopError:
+        # No operations, construct empty kernel
+        return builder.construct_empty_kernel(kernel_name)
 
 
 class CellVolumeKernelInterface(ProxyKernelInterface):

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -243,6 +243,14 @@ class KernelBuilder(KernelBuilderBase):
         self.kernel.ast = KernelBuilderBase.construct_kernel(self, name, args, body)
         return self.kernel
 
+    def construct_empty_kernel(self, name):
+        """Return None, since Firedrake needs no empty kernels.
+
+        :arg name: function name
+        :returns: None
+        """
+        return None
+
 
 def prepare_coefficient(coefficient, name, interior_facet=False):
     """Bridges the kernel interface and the GEM abstraction for

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -99,14 +99,14 @@ class KernelBuilder(KernelBuilderBase):
             self.coefficient_map.update(zip(coeffs, expressions))
 
     def construct_kernel(self, name, body):
-        """Construct a fully built :class:`Kernel`.
+        """Construct a fully built kernel function.
 
         This function contains the logic for building the argument
         list for assembly kernels.
 
         :arg name: function name
         :arg body: function body (:class:`coffee.Block` node)
-        :returns: :class:`Kernel` object
+        :returns: a COFFEE function definition object
         """
         args = [self.local_tensor]
         args.extend(self.coefficient_args)
@@ -129,6 +129,17 @@ class KernelBuilder(KernelBuilderBase):
             args.append(coffee.Decl("int", coffee.Symbol("cell_orientation")))
 
         return KernelBuilderBase.construct_kernel(self, name, args, body)
+
+    def construct_empty_kernel(self, name):
+        """Construct an empty kernel function.
+
+        Kernel will just zero the return buffer and do nothing else.
+
+        :arg name: function name
+        :returns: a COFFEE function definition object
+        """
+        body = coffee.Block([])  # empty block
+        return self.construct_kernel(name, body)
 
     @staticmethod
     def require_cell_orientations():

--- a/tsfc/ufl2gem.py
+++ b/tsfc/ufl2gem.py
@@ -59,6 +59,18 @@ class Mixin(object):
     def math_function(self, o, expr):
         return MathFunction(o._name, expr)
 
+    def bessel_i(self, o, nu, arg):
+        return MathFunction(o._name, nu, arg)
+
+    def bessel_j(self, o, nu, arg):
+        return MathFunction(o._name, nu, arg)
+
+    def bessel_k(self, o, nu, arg):
+        return MathFunction(o._name, nu, arg)
+
+    def bessel_y(self, o, nu, arg):
+        return MathFunction(o._name, nu, arg)
+
     def min_value(self, o, *ops):
         return MinValue(*ops)
 


### PR DESCRIPTION
With these changes TSFC can solve the same FFC regression test examples as UFLACS. This pull request consists of two commits:

- Empty kernels trigger a `gem.impero_utils.NoopError` exception during the compilation, which was caught in `tsfc.compile_form`, skipping the empty kernel. FFC calls `tsfc.compile_integral` directly so this exception is never caught, causing a failure for zero integrals. It seems to me that FFC wants to have empty integral. (@blechta: Is that correct?) So with this change, `NoopError` is caught in `compile_integral`, which then ask the kernel interface construct an empty kernel. The UFC kernel interface complies and constructs a real "empty" kernel, while the Firedrake interface returns `None`, which is then filtered out `tsfc.compile_form`.
- Bindings for Bessel functions. Ordinary Bessel functions translate to the C math API, so they will work with both Firedrake and FEniCS. Modified Bessel functions translate to Boost math special function calls, so they will work with FEniCS but will fail with Firedrake.