### PR TITLE
Rewrite Conditional nodes before optimisation

### DIFF
--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -531,3 +531,37 @@ def aggressive_unroll(expression):
     expression, = unroll_indexsum((expression,), predicate=lambda index: True)
     expression, = remove_componenttensors((expression,))
     return expression
+
+
+@singledispatch
+def _expand_conditional(node, self):
+    raise AssertionError("cannot handle type %s" % type(node))
+
+
+_expand_conditional.register(Node)(reuse_if_untouched)
+
+
+@_expand_conditional.register(Conditional)
+def _expand_conditional_conditional(node, self):
+    if self.predicate(node):
+        condition, then, else_ = map(self, node.children)
+        return Sum(Product(Conditional(condition, one, Zero()), then),
+                   Product(Conditional(condition, Zero(), one), else_))
+    else:
+        return reuse_if_untouched(node, self)
+
+
+def expand_conditional(expressions, predicate):
+    """Applies the following substitution rule on selected :py:class:`Conditional`s:
+
+        Conditional(a, b, c) => Conditional(a, 1, 0)*b + Conditional(a, 0, 1)*c
+
+    :arg expressions: expression DAG roots
+    :arg predicate: a predicate function on :py:class:`Conditional`s to determine
+                    whether to apply the substitution rule or not
+
+    :returns: expression DAG roots with some :py:class:`Conditional` nodes expanded
+    """
+    mapper = Memoizer(_expand_conditional)
+    mapper.predicate = predicate
+    return list(map(mapper, expressions))

--- a/gem/refactorise.py
+++ b/gem/refactorise.py
@@ -11,7 +11,8 @@ from itertools import product
 from gem.node import Memoizer, traversal
 from gem.gem import Node, Zero, Product, Sum, Indexed, ListTensor, one
 from gem.optimise import (remove_componenttensors, sum_factorise,
-                          traverse_product, traverse_sum, unroll_indexsum)
+                          traverse_product, traverse_sum, unroll_indexsum,
+                          expand_conditional)
 
 
 # Refactorisation labels
@@ -228,6 +229,10 @@ def collect_monomials(expressions, classifier):
         expressions = unroll_indexsum(expressions,
                                       predicate=lambda i: i in must_unroll)
         expressions = remove_componenttensors(expressions)
+
+    # Expand Conditional nodes which are COMPOUND
+    conditional_predicate = lambda node: classifier(node) == COMPOUND
+    expressions = expand_conditional(expressions, conditional_predicate)
 
     # Finally, refactorise expressions
     mapper = Memoizer(_collect_monomials)

--- a/tests/test_coffee_optimise.py
+++ b/tests/test_coffee_optimise.py
@@ -49,7 +49,7 @@ def test_loop_optimise():
 
     # Bj*Ek + Bj*Fk => (Ek + Fk)*Bj
     expr = Sum(Product(Bj, Ek), Product(Bj, Fk))
-    result, = optimise_expressions([expr], ((j,), (k,)))
+    result, = optimise_expressions([expr], (j, k))
     expected = Product(Sum(Ek, Fk), Bj)
     assert result == expected
 
@@ -57,7 +57,7 @@ def test_loop_optimise():
     # (Ek + Fk + Gk)*Bj + (Ek+Fk)*Cj
     expr = Sum(Sum(Sum(Sum(Product(Bj, Ek), Product(Bj, Fk)), Product(Bj, Gk)),
                    Product(Cj, Ek)), Product(Cj, Fk))
-    result, = optimise_expressions([expr], ((j,), (k,)))
+    result, = optimise_expressions([expr], (j, k))
     expected = Sum(Product(Sum(Sum(Ek, Fk), Gk), Bj), Product(Sum(Ek, Fk), Cj))
     assert result == expected
 
@@ -68,7 +68,7 @@ def test_loop_optimise():
                        Product(Z, Product(A2i, Product(Bj, Ek)))),
                    Product(A3i, Product(Bj, Ek))),
                Product(Z, Product(A1i, Product(Bj, Fk))))
-    result, = optimise_expressions([expr], ((j,), (k,)))
+    result, = optimise_expressions([expr], (j, k))
     expected = Product(Sum(Product(Ek, Sum(Sum(Product(Z, A1i), Product(Z, A2i)), A3i)),
                            Product(Fk, Product(Z, A1i))), Bj)
     assert result == expected

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -37,7 +37,7 @@ def _handle_conditional_conditional(node, self):
     if self.predicate(node):
         return Sum(Product(Conditional(condition, one, Zero()), then),
                    Product(Conditional(condition, Zero(), one), else_))
-    return Conditional(condition, then, else_)
+    return node.reconstruct(condition, then, else_)
 
 
 def handle_conditional(expressions, predicate):

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -46,7 +46,9 @@ def handle_conditional(expressions, argument_indices):
     """Rewrite :class:`Conditional` nodes as:
        Conditional(condition, 1, 0) * THEN + Conditional(condition, 0, 1) * ELSE
     so that factorisation can occur across THEN and ELSE branches.
-    :param expressions: list of GEM DAGs
+    :arg expressions: list of GEM DAGs
+    :arg argument_indices: tuple of argument indices
+
     :return: list of GEM DAGs with :class:`Conditional` nodes rewritten
     """
     mapper = Memoizer(_handle_conditional)
@@ -78,15 +80,16 @@ def Integrals(expressions, quadrature_multiindex, argument_multiindices, paramet
     expressions = replace_delta(expressions)
     expressions = remove_componenttensors(expressions)
     expressions = replace_division(expressions)
-    return optimise_expressions(expressions, argument_multiindices)
+    argument_indices = tuple(itertools.chain(*argument_multiindices))
+    # expressions = handle_conditional(expressions, argument_indices)
+    return optimise_expressions(expressions, argument_indices)
 
 
-def optimise_expressions(expressions, argument_multiindices):
+def optimise_expressions(expressions, argument_indices):
     """Perform loop optimisations on GEM DAGs
 
     :arg expressions: list of GEM DAGs
-    :arg argument_multiindices: tuple of argument multiindices,
-                                one multiindex for each argument
+    :arg argument_indices: tuple of argument indices
 
     :returns: list of optimised GEM DAGs
     """
@@ -94,9 +97,6 @@ def optimise_expressions(expressions, argument_multiindices):
     for n in traversal(expressions):
         if isinstance(n, Failure):
             return expressions
-
-    argument_indices = tuple(itertools.chain(*argument_multiindices))
-    expressions = handle_conditional(expressions, argument_indices)
 
     def classify(argument_indices, expression):
         n = len(argument_indices.intersection(expression.free_indices))

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -33,13 +33,11 @@ _handle_conditional.register(Node)(reuse_if_untouched)
 
 @_handle_conditional.register(Conditional)
 def _handle_conditional_conditional(node, self):
-    if not self.predicate(node):
-        return node
-    condition, then, else_ = node.children
-    then = self(then)
-    else_ = self(else_)
-    return Sum(Product(Conditional(condition, one, Zero()), then),
-               Product(Conditional(condition, Zero(), one), else_))
+    condition, then, else_ = map(self, node.children)
+    if self.predicate(node):
+        return Sum(Product(Conditional(condition, one, Zero()), then),
+                   Product(Conditional(condition, Zero(), one), else_))
+    return Conditional(condition, then, else_)
 
 
 def handle_conditional(expressions, predicate):

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -81,7 +81,7 @@ def Integrals(expressions, quadrature_multiindex, argument_multiindices, paramet
     expressions = remove_componenttensors(expressions)
     expressions = replace_division(expressions)
     argument_indices = tuple(itertools.chain(*argument_multiindices))
-    # expressions = handle_conditional(expressions, argument_indices)
+    expressions = handle_conditional(expressions, argument_indices)
     return optimise_expressions(expressions, argument_indices)
 
 

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -33,11 +33,12 @@ _handle_conditional.register(Node)(reuse_if_untouched)
 
 @_handle_conditional.register(Conditional)
 def _handle_conditional_conditional(node, self):
-    condition, then, else_ = map(self, node.children)
     if self.predicate(node):
+        condition, then, else_ = map(self, node.children)
         return Sum(Product(Conditional(condition, one, Zero()), then),
                    Product(Conditional(condition, Zero(), one), else_))
-    return node.reconstruct(condition, then, else_)
+    else:
+        return reuse_if_untouched(node, self)
 
 
 def handle_conditional(expressions, predicate):


### PR DESCRIPTION
Handle Conditional nodes by the following rewriting:

  Conditional(condition, 1, 0) * THEN + Conditional(condition, 0, 1) * ELSE

this ensures Conditional nodes do not have argument indices, and
also factorisation can occur across THEN and ELSE branches

issue #119 

BTW I notice a `NAN` from this test
`test tests/extrusion/test_cylinder.py::test_betti2_cylinder[horiz_complex0-vert_complex0]`
C code:
`double  t0  = (cell_orientations[0][0] == 1 ? -1 : (cell_orientations[0][0] == 0 ? 1 : NAN));`
not sure is that expected?