### PR TITLE
Point evaluation

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -269,13 +269,16 @@ class Power(Scalar):
         assert not base.shape
         assert not exponent.shape
 
-        # Zero folding
+        # Constant folding
         if isinstance(base, Zero):
             if isinstance(exponent, Zero):
                 raise ValueError("cannot solve 0^0")
             return Zero()
         elif isinstance(exponent, Zero):
             return one
+
+        if isinstance(base, Constant) and isinstance(exponent, Constant):
+            return Literal(base.value ** exponent.value)
 
         self = super(Power, cls).__new__(cls)
         self.children = base, exponent

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -300,7 +300,7 @@ def sum_factorise(sum_indices, factors):
         # Empty product
         return one
 
-    if len(sum_indices) > 5:
+    if len(sum_indices) > 6:
         raise NotImplementedError("Too many indices for sum factorisation!")
 
     # Form groups by free indices

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -35,6 +35,8 @@ literal_rounding.register(Node)(reuse_if_untouched)
 
 @literal_rounding.register(Literal)
 def literal_rounding_literal(node, self):
+    if not node.shape:
+        return node  # skip scalars
     table = node.array
     epsilon = self.epsilon
     # Mimic the rounding applied at COFFEE formatting, which in turn


### PR DESCRIPTION
This allows TSFC modules to be employed for generating code that evaluates UFL expressions at reference points only known at run time. Requires FInAT/FInAT#28 to actually function.