### PR TITLE
Do not skip rounding scalars that come from FIAT

### DIFF
--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -35,13 +35,11 @@ literal_rounding.register(Node)(reuse_if_untouched)
 
 @literal_rounding.register(Literal)
 def literal_rounding_literal(node, self):
-    if not node.shape:
-        return node  # skip scalars
     table = node.array
     epsilon = self.epsilon
     # Mimic the rounding applied at COFFEE formatting, which in turn
     # mimics FFC formatting.
-    one_decimal = numpy.round(table, 1)
+    one_decimal = numpy.asarray(numpy.round(table, 1))
     one_decimal[numpy.logical_not(one_decimal)] = 0  # no minus zeros
     return Literal(numpy.where(abs(table - one_decimal) < epsilon, one_decimal, table))
 


### PR DESCRIPTION
FInAT point evaluation may produce expressions that contain scalars that code from FIAT matrices. #121 updated the FFC rounding such that it does not fail on scalars by simply skipping rounding for scalars. However, that is not consistent with existing rounding practices, so this patch makes sure FIAT numbers are rounded irrespective being scalar or not.