### PR TITLE
Tensor mode

### DIFF
--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,0 +1,108 @@
+from __future__ import absolute_import, print_function, division
+
+import numpy
+import pytest
+
+from coffee.visitors import EstimateFlops
+
+from ufl import (Mesh, FunctionSpace, FiniteElement, VectorElement,
+                 Coefficient, TestFunction, TrialFunction, dx, div,
+                 inner, interval, triangle, tetrahedron, dot, grad)
+
+from tsfc import compile_form
+
+
+def mass(cell, degree):
+    m = Mesh(VectorElement('CG', cell, 1))
+    V = FunctionSpace(m, FiniteElement('CG', cell, degree))
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    return u*v*dx
+
+
+def poisson(cell, degree):
+    m = Mesh(VectorElement('CG', cell, 1))
+    V = FunctionSpace(m, FiniteElement('CG', cell, degree))
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    return dot(grad(u), grad(v))*dx
+
+
+def helmholtz(cell, degree):
+    m = Mesh(VectorElement('CG', cell, 1))
+    V = FunctionSpace(m, FiniteElement('CG', cell, degree))
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    return (u*v + dot(grad(u), grad(v)))*dx
+
+
+def elasticity(cell, degree):
+    m = Mesh(VectorElement('CG', cell, 1))
+    V = FunctionSpace(m, VectorElement('CG', cell, degree))
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    def eps(u):
+        return 0.5*(grad(u) + grad(u).T)
+    return inner(eps(u), eps(v))*dx
+
+
+def count_flops(form):
+    kernel, = compile_form(form, parameters=dict(mode='tensor'))
+    return EstimateFlops().visit(kernel.ast)
+
+
+@pytest.mark.parametrize('form', [mass, poisson, helmholtz, elasticity])
+@pytest.mark.parametrize(('cell', 'order'),
+                         [(interval, 2),
+                          (triangle, 4),
+                          (tetrahedron, 6)])
+def test_bilinear(form, cell, order):
+    degrees = numpy.arange(1, 9 - 2 * cell.topological_dimension())
+    flops = [count_flops(form(cell, int(degree)))
+             for degree in degrees]
+    rates = numpy.diff(numpy.log(flops)) / numpy.diff(numpy.log(degrees + 1))
+    assert (rates < order).all()
+
+
+@pytest.mark.parametrize(('cell', 'order'),
+                         [(interval, 1),
+                          (triangle, 2),
+                          (tetrahedron, 3)])
+def test_linear(cell, order):
+    def form(cell, degree):
+        m = Mesh(VectorElement('CG', cell, 1))
+        V = FunctionSpace(m, FiniteElement('CG', cell, degree))
+        v = TestFunction(V)
+        return v*dx
+
+    degrees = numpy.arange(2, 9 - 1.5 * cell.topological_dimension())
+    flops = [count_flops(form(cell, int(degree)))
+             for degree in degrees]
+    rates = numpy.diff(numpy.log(flops)) / numpy.diff(numpy.log(degrees + 1))
+    assert (rates < order).all()
+
+
+@pytest.mark.parametrize(('cell', 'order'),
+                         [(interval, 1),
+                          (triangle, 2),
+                          (tetrahedron, 3)])
+def test_functional(cell, order):
+    def form(cell, degree):
+        m = Mesh(VectorElement('CG', cell, 1))
+        V = FunctionSpace(m, VectorElement('CG', cell, degree))
+        f = Coefficient(V)
+        return div(f)*dx
+
+    dim = cell.topological_dimension()
+    degrees = numpy.arange(1, 7 - dim) + (3 - dim)
+    flops = [count_flops(form(cell, int(degree)))
+             for degree in degrees]
+    rates = numpy.diff(numpy.log(flops)) / numpy.diff(numpy.log(degrees + 1))
+    assert (rates < order).all()
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -386,6 +386,8 @@ def pick_mode(mode):
         import tsfc.coffee_mode as m
     elif mode == "spectral":
         import tsfc.spectral as m
+    elif mode == "tensor":
+        import tsfc.tensor as m
     else:
         raise ValueError("Unknown mode: {}".format(mode))
     return m

--- a/tsfc/tensor.py
+++ b/tsfc/tensor.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import, print_function, division
+from six import iteritems
+from six.moves import zip
+
+from collections import defaultdict
+from functools import partial, reduce
+from itertools import count
+
+import numpy
+
+import gem
+from gem.optimise import remove_componenttensors, unroll_indexsum
+from gem.refactorise import ATOMIC, COMPOUND, OTHER, collect_monomials
+
+
+def einsum(factors, sum_indices):
+    """Evaluates a tensor product at compile time.
+
+    :arg factors: iterable of indexed GEM literals
+    :arg sum_indices: indices to sum over
+    :returns: a single indexed GEM literal
+    """
+    # Maps the problem onto numpy.einsum
+    index2letter = defaultdict(partial(lambda c: chr(ord('i') + next(c)), count()))
+    operands = []
+    subscript_parts = []
+    for factor in factors:
+        literal, = factor.children
+        selectors = []
+        letters = []
+        for index in factor.multiindex:
+            if isinstance(index, int):
+                selectors.append(index)
+            else:
+                selectors.append(slice(None))
+                letters.append(index2letter[index])
+        operands.append(literal.array.__getitem__(selectors))
+        subscript_parts.append(''.join(letters))
+
+    result_pairs = sorted((letter, index)
+                          for index, letter in iteritems(index2letter)
+                          if index not in sum_indices)
+
+    subscripts = ','.join(subscript_parts) + '->' + ''.join(l for l, i in result_pairs)
+    tensor = numpy.einsum(subscripts, *operands)
+    return gem.Indexed(gem.Literal(tensor), tuple(i for l, i in result_pairs))
+
+
+def Integrals(expressions, quadrature_multiindex, argument_multiindices, parameters):
+    # Unroll
+    max_extent = parameters["unroll_indexsum"]
+    if max_extent:
+        def predicate(index):
+            return index.extent <= max_extent
+        expressions = unroll_indexsum(expressions, predicate=predicate)
+
+    # Refactorise
+    def classify(quadrature_indices, expression):
+        if not quadrature_indices.intersection(expression.free_indices):
+            return OTHER
+        elif isinstance(expression, gem.Indexed) and isinstance(expression.children[0], gem.Literal):
+            return ATOMIC
+        else:
+            return COMPOUND
+    classifier = partial(classify, set(quadrature_multiindex))
+
+    result = []
+    for expr, monomial_sum in zip(expressions, collect_monomials(expressions, classifier)):
+        # Select quadrature indices that are present
+        quadrature_indices = set(index for index in quadrature_multiindex
+                                 if index in expr.free_indices)
+
+        products = []
+        for sum_indices, factors, rest in monomial_sum:
+            # Collapse quadrature literals for each monomial
+            if factors or quadrature_indices:
+                replacement = einsum(remove_componenttensors(factors), quadrature_indices)
+            else:
+                replacement = gem.Literal(1)
+            # Rebuild expression
+            products.append(gem.IndexSum(gem.Product(replacement, rest), sum_indices))
+        result.append(reduce(gem.Sum, products, gem.Zero()))
+    return result
+
+
+def flatten(var_reps):
+    for variable, reps in var_reps:
+        expressions = reps
+        for expression in expressions:
+            yield (variable, expression)
+
+
+finalise_options = {}


### PR DESCRIPTION
Adds new mode similar to FFC's tensor representation. This mode is slightly more general, since rather than trying express the whole kernel as a tensor contraction between a reference tensor and a "geometry tensor", this instead tries to eliminate the quadrature loop through compile-time evaluation. This allows the form to be arbitrarily complex in quantities that are cellwise constant, otherwise this mode subject to about the same limitation as FFC tensor.

This pull request consist of three parts:
1. Extension of the refactoriser to handle duplicate indices
2. Tensor mode
3. Test cases

The refactoriser extension deals with the `(sum_i a_i)*(sum_i b_i) ===> \sum_{i,i'} a_i*b_{i'}` expansion case which requires renaming the index of `b` from `i` to `i'`. This case cannot happen with argument factorisation.