### PR TITLE
Implement ip and remove PuLP

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,4 +1,3 @@
 numpy
 singledispatch
 six
-PuLP>=1.6.5

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -142,10 +142,12 @@ def find_optimal_atomics(monomials, argument_indices):
     :returns: list of atomic GEM expressions
     """
     atomics = OrderedDict()
+    idx = 0
     for monomial in monomials:
         for atomic in monomial.atomics:
-            atomics[atomic] = 0
-    atomics = list(atomics.keys())
+            if atomic not in atomics:
+                atomics[atomic] = idx
+                idx += 1
 
     if len(atomics) <= 1:
         return tuple(atomics)
@@ -165,7 +167,7 @@ def find_optimal_atomics(monomials, argument_indices):
         else:
             return len(sol1) < len(sol2)
 
-    return tuple(sorted(solve_ip(atomics, is_feasible, compare)))
+    return tuple(sorted(solve_ip(list(atomics.keys()), is_feasible, compare), key=atomics.get))
 
 
 def factorise_atomics(monomials, optimal_atomics, argument_indices):

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -157,10 +157,7 @@ def find_optimal_atomics(monomials, argument_indices):
         # Solution is only feasible if it intersects with all monomials
         # Potentially can improve this by keeping track of violated constraints
         # and suggest the next atomic to try (instead of just returning True or False)
-        for monomial in monomials:
-            if not solution.intersection(monomial.atomics):
-                return False
-        return True
+        return all(solution.intersection(monomial.atomics) for monomial in monomials)
 
     def compare(sol1, sol2):
         if len(sol1) == len(sol2):

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -113,10 +113,10 @@ def solve_ip(size, is_feasible, compare):
     variable to 1 recursively, and stop the recursion early by comparing with
     the optimal solution at entry. At worst case this is 2^N (as this is a
     NP-hard problem), but recursions can be trimmed as soon as a reasonable
-    solutions have been found. One potential improvement is to keep track of
+    solution have been found. One potential improvement is to keep track of
     violated constraints at each step, and only try to set the variables which
     could help these constraints in the next step. This will help find decent
-    solutions faster with additional overhead of maintaining a list of
+    solutions faster with the additional overhead of maintaining a list of
     violated constraints and finding helpful variables.
 
     :param size: number of 0-1 variables


### PR DESCRIPTION
This PR implements our own IP for coffee mode instead of calling PuLP

- Passes all firedrake tests.
- Matches the flop counts on my test suits.
- Time performance is largely the same as now, if not slightly better (e.g. holzapfel from 5.2s to 4.7s, hyperelasticity in 3D from 3.6s to 3.3s).

Inefficiencies in the algorithm:

- Can do better by keeping track of violated constraints, instead of repeated testing constraints that are already fulfilled across levels.

This supersedes, and thus closes #117.