### PR TITLE
Some convergence between 'coffee' and 'spectral' modes

### DIFF
--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -6,19 +6,19 @@ from functools import partial
 from six import iteritems, iterkeys
 from six.moves import filter
 from collections import defaultdict
-from gem.optimise import (replace_division, make_sum, make_product,
-                          unroll_indexsum, replace_delta, remove_componenttensors)
-from gem.refactorise import Monomial, ATOMIC, COMPOUND, OTHER, collect_monomials
+from gem.optimise import make_sum, make_product, replace_division, unroll_indexsum
+from gem.refactorise import Monomial, collect_monomials
 from gem.node import traversal
-from gem.gem import Indexed, IndexSum, Failure, one, index_sum
+from gem.gem import IndexSum, Failure, one, index_sum
 from gem.utils import groupby
 
-
 import tsfc.vanilla as vanilla
+from tsfc.spectral import classify
+
 
 flatten = vanilla.flatten
 
-finalise_options = dict(replace_delta=False, remove_componenttensors=False)
+finalise_options = dict(remove_componenttensors=False)
 
 
 def Integrals(expressions, quadrature_multiindex, argument_multiindices, parameters):
@@ -42,8 +42,6 @@ def Integrals(expressions, quadrature_multiindex, argument_multiindices, paramet
         expressions = unroll_indexsum(expressions, predicate=predicate)
     # Choose GEM expression as the integral representation
     expressions = [index_sum(e, quadrature_multiindex) for e in expressions]
-    expressions = replace_delta(expressions)
-    expressions = remove_componenttensors(expressions)
     expressions = replace_division(expressions)
     argument_indices = tuple(itertools.chain(*argument_multiindices))
     return optimise_expressions(expressions, argument_indices)
@@ -61,18 +59,6 @@ def optimise_expressions(expressions, argument_indices):
     for n in traversal(expressions):
         if isinstance(n, Failure):
             return expressions
-
-    def classify(argument_indices, expression):
-        n = len(argument_indices.intersection(expression.free_indices))
-        if n == 0:
-            return OTHER
-        elif n == 1:
-            if isinstance(expression, Indexed):
-                return ATOMIC
-            else:
-                return COMPOUND
-        else:
-            return COMPOUND
 
     # Apply argument factorisation unconditionally
     classifier = partial(classify, set(argument_indices))

--- a/tsfc/spectral.py
+++ b/tsfc/spectral.py
@@ -4,7 +4,7 @@ from six.moves import map, zip
 from functools import partial
 from itertools import chain
 
-from gem import index_sum
+from gem import Delta, Indexed, index_sum
 from gem.optimise import delta_elimination as _delta_elimination
 from gem.optimise import sum_factorise as _sum_factorise
 from gem.optimise import unroll_indexsum
@@ -45,17 +45,21 @@ def Integrals(expressions, quadrature_multiindex, argument_multiindices, paramet
             for e in expressions]
 
 
-def flatten(var_reps):
-    # Classifier for argument factorisation
-    def classify(argument_indices, expression):
-        n = len(argument_indices.intersection(expression.free_indices))
-        if n == 0:
-            return OTHER
-        elif n == 1:
+def classify(argument_indices, expression):
+    """Classifier for argument factorisation"""
+    n = len(argument_indices.intersection(expression.free_indices))
+    if n == 0:
+        return OTHER
+    elif n == 1:
+        if isinstance(expression, (Delta, Indexed)):
             return ATOMIC
         else:
             return COMPOUND
+    else:
+        return COMPOUND
 
+
+def flatten(var_reps):
     for variable, reps in var_reps:
         # Destructure representation
         argument_indicez, expressions = zip(*reps)
@@ -74,4 +78,4 @@ def flatten(var_reps):
                 yield (variable, sum_factorise(*monomial))
 
 
-finalise_options = {}
+finalise_options = dict(remove_componenttensors=False)


### PR DESCRIPTION
Spectral mode:
- Adopts tighter argument factorisation from `'coffee'` mode.
  Not necessary for sum factorisation, but useful for delta elimination on arguments.
- Not needed to call `remove_componenttensors` afterwards, as no new `ComponentTensor` nodes are introduced.

Coffee mode:
- No longer lowers `Delta` nodes early.
- Eliminate unnecessary `remove_componenttensors` call at the beginning. `collect_monomials` takes care of this itself.