### PR TITLE
Preliminary additions and fixes for supporting enriched FInAT element

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -799,7 +799,7 @@ def reshape(expression, *shapes):
     shape_of = dict(zip(indexes, shapes))
 
     dim2idxs_ = []
-    indices = []
+    indices = [[] for _ in range(len(indexes))]
     for offset, idxs in dim2idxs:
         idxs_ = []
         for idx in idxs:
@@ -811,13 +811,13 @@ def reshape(expression, *shapes):
                 raise ValueError("Shape {} does not match extent {}.".format(shape, dim))
             strides = strides_of(shape)
             for extent, stride_ in zip(shape, strides):
-                index = Index(extent=extent)
-                idxs_.append((index, stride_ * stride))
-                indices.append(index)
+                index_ = Index(extent=extent)
+                idxs_.append((index_, stride_ * stride))
+                indices[indexes.index(index)].append(index_)
         dim2idxs_.append((offset, tuple(idxs_)))
 
     expr = FlexiblyIndexed(variable, tuple(dim2idxs_))
-    return ComponentTensor(expr, tuple(indices))
+    return ComponentTensor(expr, tuple(chain.from_iterable(indices)))
 
 
 def view(expression, *slices):
@@ -831,7 +831,7 @@ def view(expression, *slices):
     slice_of = dict(zip(indexes, slices))
 
     dim2idxs_ = []
-    indices = []
+    indices = [None] * len(slices)
     for offset, idxs in dim2idxs:
         offset_ = offset
         idxs_ = []
@@ -850,7 +850,7 @@ def view(expression, *slices):
             offset_ += start * stride
             extent = 1 + (stop - start - 1) // step
             index_ = Index(extent=extent)
-            indices.append(index_)
+            indices[indexes.index(index)] = index_
             idxs_.append((index_, step * stride))
         dim2idxs_.append((offset_, tuple(idxs_)))
 

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -33,8 +33,8 @@ __all__ = ['Node', 'Identity', 'Literal', 'Zero', 'Failure',
            'MathFunction', 'MinValue', 'MaxValue', 'Comparison',
            'LogicalNot', 'LogicalAnd', 'LogicalOr', 'Conditional',
            'Index', 'VariableIndex', 'Indexed', 'ComponentTensor',
-           'IndexSum', 'ListTensor', 'Delta', 'index_sum',
-           'partial_indexed', 'reshape', 'view']
+           'IndexSum', 'ListTensor', 'Concatenate', 'Delta',
+           'index_sum', 'partial_indexed', 'reshape', 'view']
 
 
 class NodeMeta(type):
@@ -675,6 +675,23 @@ class ListTensor(Node):
 
     def get_hash(self):
         return hash((type(self), self.shape, self.children))
+
+
+class Concatenate(Node):
+    """Flattens and concatenates GEM expressions by shape.
+
+    Similar to what UFL MixedElement does to value shape.  For
+    example, if children have shapes (2, 2), (), and (3,) then the
+    concatenated expression has shape (8,).
+    """
+    __slots__ = ('children',)
+
+    def __init__(self, *children):
+        self.children = children
+
+    @property
+    def shape(self):
+        return (sum(numpy.prod(child.shape, dtype=int) for child in self.children),)
 
 
 class Delta(Scalar, Terminal):

--- a/gem/interpreter.py
+++ b/gem/interpreter.py
@@ -115,20 +115,20 @@ def _evaluate(expression, self):
     raise ValueError("Unhandled node type %s" % type(expression))
 
 
-@_evaluate.register(gem.Zero)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.Zero)
+def _evaluate_zero(e, self):
     """Zeros produce an array of zeros."""
     return Result(numpy.zeros(e.shape, dtype=float))
 
 
-@_evaluate.register(gem.Constant)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.Constant)
+def _evaluate_constant(e, self):
     """Constants return their array."""
     return Result(e.array)
 
 
-@_evaluate.register(gem.Variable)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.Variable)
+def _evaluate_variable(e, self):
     """Look up variables in the provided bindings."""
     try:
         val = self.bindings[e]
@@ -140,11 +140,11 @@ def _(e, self):
     return Result(val)
 
 
-@_evaluate.register(gem.Power)  # noqa: F811
+@_evaluate.register(gem.Power)
 @_evaluate.register(gem.Division)
 @_evaluate.register(gem.Product)
 @_evaluate.register(gem.Sum)
-def _(e, self):
+def _evaluate_operator(e, self):
     op = {gem.Product: operator.mul,
           gem.Division: operator.div,
           gem.Sum: operator.add,
@@ -157,8 +157,8 @@ def _(e, self):
     return result
 
 
-@_evaluate.register(gem.MathFunction)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.MathFunction)
+def _evaluate_mathfunction(e, self):
     ops = [self(o) for o in e.children]
     result = Result.empty(*ops)
     names = {"abs": abs,
@@ -169,9 +169,9 @@ def _(e, self):
     return result
 
 
-@_evaluate.register(gem.MaxValue)  # noqa: F811
+@_evaluate.register(gem.MaxValue)
 @_evaluate.register(gem.MinValue)
-def _(e, self):
+def _evaluate_minmaxvalue(e, self):
     ops = [self(o) for o in e.children]
     result = Result.empty(*ops)
     op = {gem.MinValue: min,
@@ -181,8 +181,8 @@ def _(e, self):
     return result
 
 
-@_evaluate.register(gem.Comparison)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.Comparison)
+def _evaluate_comparison(e, self):
     ops = [self(o) for o in e.children]
     op = {">": operator.gt,
           ">=": operator.ge,
@@ -196,8 +196,8 @@ def _(e, self):
     return result
 
 
-@_evaluate.register(gem.LogicalNot)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.LogicalNot)
+def _evaluate_logicalnot(e, self):
     val = self(e.children[0])
     assert val.arr.dtype == numpy.dtype("bool")
     result = Result.empty(val, bool)
@@ -206,8 +206,8 @@ def _(e, self):
     return result
 
 
-@_evaluate.register(gem.LogicalAnd)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.LogicalAnd)
+def _evaluate_logicaland(e, self):
     a, b = [self(o) for o in e.children]
     assert a.arr.dtype == numpy.dtype("bool")
     assert b.arr.dtype == numpy.dtype("bool")
@@ -218,8 +218,8 @@ def _(e, self):
     return result
 
 
-@_evaluate.register(gem.LogicalOr)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.LogicalOr)
+def _evaluate_logicalor(e, self):
     a, b = [self(o) for o in e.children]
     assert a.arr.dtype == numpy.dtype("bool")
     assert b.arr.dtype == numpy.dtype("bool")
@@ -230,8 +230,8 @@ def _(e, self):
     return result
 
 
-@_evaluate.register(gem.Conditional)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.Conditional)
+def _evaluate_conditional(e, self):
     cond, then, else_ = [self(o) for o in e.children]
     assert cond.arr.dtype == numpy.dtype("bool")
     result = Result.empty(cond, then, else_)
@@ -243,8 +243,8 @@ def _(e, self):
     return result
 
 
-@_evaluate.register(gem.Indexed)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.Indexed)
+def _evaluate_indexed(e, self):
     """Indexing maps shape to free indices"""
     val = self(e.children[0])
     fids = tuple(i for i in e.multiindex if isinstance(i, gem.Index))
@@ -270,8 +270,8 @@ def _(e, self):
     return Result(val[idx], val.fids + fids)
 
 
-@_evaluate.register(gem.ComponentTensor)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.ComponentTensor)
+def _evaluate_componenttensor(e, self):
     """Component tensors map free indices to shape."""
     val = self(e.children[0])
     axes = []
@@ -290,8 +290,8 @@ def _(e, self):
                   tuple(fids))
 
 
-@_evaluate.register(gem.IndexSum)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.IndexSum)
+def _evaluate_indexsum(e, self):
     """Index sums reduce over the given axis."""
     val = self(e.children[0])
     idx = tuple(map(val.fids.index, e.multiindex))
@@ -299,8 +299,8 @@ def _(e, self):
     return Result(val.arr.sum(axis=idx), rfids)
 
 
-@_evaluate.register(gem.ListTensor)  # noqa: F811
-def _(e, self):
+@_evaluate.register(gem.ListTensor)
+def _evaluate_listtensor(e, self):
     """List tensors just turn into arrays."""
     ops = [self(o) for o in e.children]
     tmp = Result.empty(*ops)

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -187,6 +187,12 @@ def _select_expression(expressions, index):
     if types <= {Literal, Zero, Failure}:
         return partial_indexed(ListTensor(expressions), (index,))
 
+    if types <= {ComponentTensor, Zero}:
+        shape, = set(e.shape for e in expressions)
+        multiindex = tuple(Index(extent=d) for d in shape)
+        children = remove_componenttensors([Indexed(e, multiindex) for e in expressions])
+        return ComponentTensor(_select_expression(children, index), multiindex)
+
     if len(types) == 1:
         cls, = types
         if cls.__front__ or cls.__back__:


### PR DESCRIPTION
- Adds new GEM node: `Concatenate`
- Fixes an accidental axis reordering issue with `gem.view` and `gem.reshape`, which apply to run-time kernel arguments.
- Teaches `gem.select_expression` (which factorises element expressions for facet integrals) about `ComponentTensor`s (which will appear inside `Concatenate` nodes).

Related to FInAT/FInAT#19.