### PR TITLE
Cutoff ilp

### DIFF
--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -12,6 +12,7 @@ from gem.node import traversal
 from gem.gem import IndexSum, Failure, Sum, one
 from gem.utils import groupby
 
+from tsfc.logging import logger
 import tsfc.spectral as spectral
 
 
@@ -110,6 +111,8 @@ def solve_ip(variables, is_feasible, key):
     solution = set()
 
     def solve(idx):
+        if idx > 15:
+            return
         if idx >= len(variables):
             return
         if key(solution) >= key(optimal_solution):
@@ -154,6 +157,8 @@ def find_optimal_atomics(monomials, argument_indices):
         # Prefer shorter solutions, but larger extents
         return (len(solution), -extent)
 
+    if len(atomics) > 16:
+        logger.warning("Have more than 16 atomics (%d), solution to ILP problem will not be optimal", len(atomics))
     optimal_atomics = solve_ip(atomics, is_feasible, key=cost)
     return tuple(atomic for atomic in atomics if atomic in optimal_atomics)
 


### PR DESCRIPTION
Does two things:

1. Adds cut off to ILP so we don't do too much.  Set arbitrarily at 16, so we don't do more than 2^16 things.

2. Attacks the major constant factor in the ILP program.

Running the test from #135, we have:

```sh
# With 1. (But basically "before", because there are 16 factors)
$ python many_monos.py 
COFFEE:PERF_OK COFFEE finished in 0.00246692 seconds (flops: 96 -> 96)
tsfc:INFO compute_form_data finished in 0.173406 seconds.
tsfc:INFO compile_integral finished in 12.517 seconds.
tsfc:INFO TSFC finished in 12.6912 seconds.

# With 2 (lipstick on the pig)
$ python many_monos.py 
COFFEE:PERF_OK COFFEE finished in 0.00254011 seconds (flops: 96 -> 96)
tsfc:INFO compute_form_data finished in 0.163301 seconds.
tsfc:INFO compile_integral finished in 2.17711 seconds.
tsfc:INFO TSFC finished in 2.3412 seconds.
```
 