### PR TITLE
Use FInAT mixed element and update UFC kernel interface

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -699,7 +699,7 @@ class Concatenate(Node):
 
     def __new__(cls, *children):
         if all(isinstance(child, Zero) for child in children):
-            size = sum(numpy.prod(child.shape, dtype=int) for child in children)
+            size = int(sum(numpy.prod(child.shape, dtype=int) for child in children))
             return Zero((size,))
 
         self = super(Concatenate, cls).__new__(cls)
@@ -708,7 +708,7 @@ class Concatenate(Node):
 
     @property
     def shape(self):
-        return (sum(numpy.prod(child.shape, dtype=int) for child in self.children),)
+        return (int(sum(numpy.prod(child.shape, dtype=int) for child in self.children)),)
 
 
 class Delta(Scalar, Terminal):

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -697,8 +697,14 @@ class Concatenate(Node):
     """
     __slots__ = ('children',)
 
-    def __init__(self, *children):
+    def __new__(cls, *children):
+        if all(isinstance(child, Zero) for child in children):
+            size = sum(numpy.prod(child.shape, dtype=int) for child in children)
+            return Zero((size,))
+
+        self = super(Concatenate, cls).__new__(cls)
         self.children = children
+        return self
 
     @property
     def shape(self):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -28,7 +28,6 @@ from finat.quadrature import AbstractQuadratureRule, make_quadrature
 from tsfc import fem, ufl_utils
 from tsfc.coffee import SCALAR_TYPE, generate as generate_coffee
 from tsfc.fiatinterface import as_fiat_cell
-from tsfc.finatinterface import create_element
 from tsfc.logging import logger
 from tsfc.parameters import default_parameters
 
@@ -99,14 +98,14 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     fiat_cell = as_fiat_cell(cell)
     integration_dim, entity_ids = lower_integral_type(fiat_cell, integral_type)
 
-    argument_multiindices = tuple(create_element(arg.ufl_element()).get_indices()
-                                  for arg in arguments)
     quadrature_indices = []
 
     # Dict mapping domains to index in original_form.ufl_domains()
     domain_numbering = form_data.original_form.domain_numbering()
     builder = interface.KernelBuilder(integral_type, integral_data.subdomain_id,
                                       domain_numbering[integral_data.domain])
+    argument_multiindices = tuple(builder.create_element(arg.ufl_element()).get_indices()
+                                  for arg in arguments)
     return_variables = builder.set_arguments(arguments, argument_multiindices)
 
     coordinates = ufl_utils.coordinate_coefficient(mesh)

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -31,7 +31,7 @@ from gem.utils import cached_property
 from finat.quadrature import make_quadrature
 
 from tsfc import ufl2gem
-from tsfc.finatinterface import create_element, as_fiat_cell
+from tsfc.finatinterface import as_fiat_cell
 from tsfc.kernel_interface import ProxyKernelInterface
 from tsfc.modified_terminals import analyse_modified_terminal
 from tsfc.parameters import NUMPY_TYPE, PARAMETERS
@@ -319,7 +319,7 @@ def fiat_to_ufl(fiat_dict, order):
 def translate_argument(terminal, mt, ctx):
     argument_multiindex = ctx.argument_multiindices[terminal.number()]
     sigma = tuple(gem.Index(extent=d) for d in mt.expr.ufl_shape)
-    element = create_element(terminal.ufl_element())
+    element = ctx.create_element(terminal.ufl_element())
 
     def callback(entity_id):
         finat_dict = ctx.basis_evaluation(element, mt.local_derivatives, entity_id)
@@ -346,7 +346,7 @@ def translate_coefficient(terminal, mt, ctx):
         assert mt.local_derivatives == 0
         return vec
 
-    element = create_element(terminal.ufl_element())
+    element = ctx.create_element(terminal.ufl_element())
 
     # Collect FInAT tabulation for all entities
     per_derivative = collections.defaultdict(list)

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -137,9 +137,16 @@ def convert_finiteelement(element):
     return lmbda(cell, element.degree())
 
 
+# EnrichedElement case
 @convert.register(ufl.EnrichedElement)
 def convert_enrichedelement(element):
     return finat.EnrichedElement([create_element(elem) for elem in element._elements])
+
+
+# Generic MixedElement case
+@convert.register(ufl.MixedElement)
+def convert_mixedelement(element):
+    return finat.MixedElement([create_element(elem) for elem in element.sub_elements()])
 
 
 # VectorElement case

--- a/tsfc/kernel_interface/__init__.py
+++ b/tsfc/kernel_interface/__init__.py
@@ -23,5 +23,10 @@ class KernelInterface(with_metaclass(ABCMeta)):
     def entity_number(self, restriction):
         """Facet or vertex number as a GEM index."""
 
+    @abstractmethod
+    def create_element(self, element):
+        """Create a FInAT element (suitable for tabulating with) given
+        a UFL element."""
+
 
 ProxyKernelInterface = make_proxy_class('ProxyKernelInterface', KernelInterface)

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -91,6 +91,11 @@ class KernelBuilderBase(_KernelBuilderBase):
                 return True
         return False
 
+    def create_element(self, element):
+        """Create a FInAT element (suitable for tabulating with) given
+        a UFL element."""
+        return create_element(element)
+
 
 class ExpressionKernelBuilder(KernelBuilderBase):
     """Builds expression kernels for UFL interpolation in Firedrake."""

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -18,7 +18,7 @@ from tsfc.coffee import SCALAR_TYPE
 
 def create_element(element):
     # UFC DoF ordering for vector/tensor elements is XXXX YYYY ZZZZ.
-    return _create_element(element, vector_transpose=True)
+    return _create_element(element, shape_innermost=False)
 
 
 class KernelBuilder(KernelBuilderBase):

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -12,8 +12,13 @@ from gem.optimise import remove_componenttensors as prune
 from finat import TensorFiniteElement
 
 from tsfc.kernel_interface.common import KernelBuilderBase
-from tsfc.finatinterface import create_element
+from tsfc.finatinterface import create_element as _create_element
 from tsfc.coffee import SCALAR_TYPE
+
+
+def create_element(element):
+    # UFC DoF ordering for vector/tensor elements is XXXX YYYY ZZZZ.
+    return _create_element(element, vector_transpose=True)
 
 
 class KernelBuilder(KernelBuilderBase):
@@ -142,6 +147,11 @@ class KernelBuilder(KernelBuilderBase):
     def needs_cell_orientations(ir):
         # UFC tabulate_tensor always have cell orientations
         return True
+
+    def create_element(self, element):
+        """Create a FInAT element (suitable for tabulating with) given
+        a UFL element."""
+        return create_element(element)
 
 
 def prepare_coefficient(coefficient, num, name, interior_facet=False):

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -202,6 +202,9 @@ class CoefficientSplitter(MultiFunction, ModifiedTerminalMixin):
 def split_coefficients(expression, split):
     """Split mixed coefficients, so mixed elements need not be
     implemented."""
+    if split is None:
+        return expression
+
     splitter = CoefficientSplitter(split)
     return map_expr_dag(splitter, expression)
 

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -201,7 +201,12 @@ class CoefficientSplitter(MultiFunction, ModifiedTerminalMixin):
 
 def split_coefficients(expression, split):
     """Split mixed coefficients, so mixed elements need not be
-    implemented."""
+    implemented.
+
+    :arg split: A :py:class:`dict` mapping each mixed coefficient to a
+                sequence of subcoefficients.  If None, calling this
+                function is a no-op.
+    """
     if split is None:
         return expression
 


### PR DESCRIPTION
These changes mostly affect FEniCS, though there are some common refactorings, such as `create_element` is now accessed through the kernel interface, because Firedrake and FEniCS need different DoF ordering when translating UFL `VectorElement`/`TensorElement`. Similarly, the common `tsfc.finatinterface.create_element` gets an optional argument to choose between these two translations.

List of FEniCS-specific changes:
- `MixedElement` now comes from FInAT/FInAT#37, so mixed arguments don't lose structure. Essentially form splitting is applied in the form compiler using the existing element splitting infrastructure (#132).
- Coefficient splitting now longer applied for UFC, because FInAT mixed elements allow unhindered access to the underlying structure of the subelements, so the kernel interface is simplified.
- Vector/tensor DoF transposition trick is no longer applied for arguments and coefficients, however, it is now applied for coordinates, because in FEniCS coordinates XYZ XYZ XYZ XYZ ordering, while ordinary coefficients have XXXX YYYY ZZZZ.