### PR TITLE
Handle Failure nodes in the interpreter

### DIFF
--- a/gem/interpreter.py
+++ b/gem/interpreter.py
@@ -122,6 +122,12 @@ def _evaluate_zero(e, self):
     return Result(numpy.zeros(e.shape, dtype=float))
 
 
+@_evaluate.register(gem.Failure)
+def _evaluate_failure(e, self):
+    """Failure nodes produce NaNs."""
+    return Result(numpy.full(e.shape, numpy.nan, dtype=float))
+
+
 @_evaluate.register(gem.Constant)
 def _evaluate_constant(e, self):
     """Constants return their array."""


### PR DESCRIPTION
Map to an appropriately shaped array of NaNs.  Necessary if anyone
ever asks for entity_support_dofs on a trace element.