### PR TITLE
impero: Swap order of processing in preprocess_gem

### DIFF
--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -35,10 +35,10 @@ class NoopError(Exception):
 
 def preprocess_gem(expressions, replace_delta=True, remove_componenttensors=True):
     """Lower GEM nodes that cannot be translated to C directly."""
-    if replace_delta:
-        expressions = optimise.replace_delta(expressions)
     if remove_componenttensors:
         expressions = optimise.remove_componenttensors(expressions)
+    if replace_delta:
+        expressions = optimise.replace_delta(expressions)
     return expressions
 
 


### PR DESCRIPTION
We should remove component tensors before simplifying deltas.