### PR TITLE
Add a library implementation of dynamic scoping and revise FInAT interface

### DIFF
--- a/gem/utils.py
+++ b/gem/utils.py
@@ -3,6 +3,13 @@ from six import viewitems
 
 import collections
 
+try:
+    # Python 3.3+
+    from collections.abc import MutableSet
+except ImportError:
+    # Python up to 3.2
+    from collections import MutableSet
+
 
 # This is copied from PyOP2, and it is here to be available for both
 # FInAT and TSFC without depending on PyOP2.
@@ -58,6 +65,28 @@ def make_proxy_class(name, cls):
         if not attr.startswith('_'):
             dct[attr] = make_proxy_property(attr)
     return type(name, (), dct)
+
+
+class BlackholeSet(MutableSet):
+    """A mutable set that discards elements, like /dev/null."""
+
+    def __contains__(self, elem):
+        raise NotImplementedError("Cannot peek a blackhole!")
+
+    def __iter__(self):
+        raise NotImplementedError("Cannot peek a blackhole!")
+
+    def __len__(self):
+        raise NotImplementedError("Cannot peek a blackhole!")
+
+    def add(self, elem):
+        pass  # thanks!
+
+    def update(self, others):
+        pass  # thanks!
+
+    def discard(self, elem):
+        raise NotImplementedError("Nothing ever discarded here.")
 
 
 # Implementation of dynamically scoped variables in Python.

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,4 +1,4 @@
 git+https://github.com/coneoproject/COFFEE#egg=COFFEE
 git+https://github.com/firedrakeproject/ufl.git#egg=ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
-git+https://github.com/FInAT/FInAT.git#egg=finat
+git+https://github.com/FInAT/FInAT.git@more-fiat#egg=finat

--- a/tests/test_create_finat_element.py
+++ b/tests/test_create_finat_element.py
@@ -8,7 +8,6 @@ from tsfc.finatinterface import create_element, supported_elements
 
 @pytest.fixture(params=["BDM",
                         "BDFM",
-                        "DRT",
                         "Lagrange",
                         "N1curl",
                         "N2curl",

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -43,7 +43,7 @@ supported_elements = {
     "Bubble": finat.Bubble,
     "Crouzeix-Raviart": finat.CrouzeixRaviart,
     "Discontinuous Lagrange": finat.DiscontinuousLagrange,
-    "Discontinuous Raviart-Thomas": finat.DiscontinuousRaviartThomas,
+    "Discontinuous Raviart-Thomas": lambda c, d: finat.DiscontinuousElement(finat.RaviartThomas(c, d)),
     "Discontinuous Taylor": finat.DiscontinuousTaylor,
     "Gauss-Legendre": finat.GaussLegendre,
     "Gauss-Lobatto-Legendre": finat.GaussLobattoLegendre,

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -244,40 +244,6 @@ class PickRestriction(MultiFunction, ModifiedTerminalMixin):
             return o
 
 
-def _spanning_degree(cell, degree):
-    if cell is None:
-        assert degree == 0
-        return degree
-    elif cell.cellname() in ["interval", "triangle", "tetrahedron"]:
-        return degree
-    elif cell.cellname() == "quadrilateral":
-        # TODO: Tensor-product space assumed
-        return 2 * degree
-    elif isinstance(cell, ufl.TensorProductCell):
-        try:
-            # A component cell might be a quadrilateral, so recurse.
-            return sum(_spanning_degree(sub_cell, d)
-                       for sub_cell, d in zip(cell.sub_cells(), degree))
-        except TypeError:
-            assert degree == 0
-            return 0
-    else:
-        raise ValueError("Unknown cell %s" % cell.cellname())
-
-
-def spanning_degree(element):
-    """Determine the degree of the polynomial space spanning an element.
-
-    :arg element: The element to determine the degree of.
-
-    .. warning::
-
-       For non-simplex elements, this assumes a tensor-product
-       space.
-    """
-    return _spanning_degree(element.cell(), element.degree())
-
-
 def ufl_reuse_if_untouched(o, *ops):
     """Reuse object if operands are the same objects."""
     if all(a is b for a, b in zip(o.ufl_operands, ops)):


### PR DESCRIPTION
### The issue

Greenspun's tenth rule states:
> Any sufficiently complicated C or Fortran program contains an ad-hoc, informally-specified, bug-ridden, slow implementation of half of Common Lisp.

Python is a complicated C program, unfortunately, dynamic scoping belongs to the half of Common Lisp that Python does not implement. It is a shame, because even Perl 5 has it.

### Motivation (in general)

TSFC code is too explicit and clear, dynamic scoping would help to establish dependencies through the call stack that are not lexically explicit.

### Motivation (currently)

This is coming in anticipation of the changes required to use with runtime tabulated elements in Themis. For runtime tabulated elements, element conversion may potentially require two more parameter options. This pull request brings in the infrastructure for arbitrary number of parameter options, including efficient caching of converted elements.

### Other changes

This pull request must be merged at the same time with FInAT/FInAT#39 which wraps a more complete set of FIAT elements. At the same FInAT interface will not have a generic fallback on the FIAT interface, such fallback only happens explicitly for `RestrictedElement`s and should happen for `NodalEnrichedElement`s (currently not translated).