### PR TITLE
Add a library implementation of dynamic scoping

### DIFF
--- a/gem/utils.py
+++ b/gem/utils.py
@@ -40,9 +40,7 @@ def groupby(iterable, key=None):
 
 
 def make_proxy_class(name, cls):
-    """Constructs a proxy class for a given class.  Instance attributes
-    are supposed to be listed e.g. with the unset_attribute decorator,
-    so that this function find them and create wrappers for them.
+    """Constructs a proxy class for a given class.
 
     :arg name: name of the new proxy class
     :arg cls: the wrapee class to create a proxy for


### PR DESCRIPTION
Okay, I am not going to use this in production, but it would be nice to have it around for prototyping.

> ### The issue
> 
> Greenspun's tenth rule states:
> > Any sufficiently complicated C or Fortran program contains an ad-hoc, informally-specified, bug-ridden, slow implementation of half of Common Lisp.
> 
> Python is a complicated C program, unfortunately, dynamic scoping belongs to the half of Common Lisp that Python does not implement. It is a shame, because even Perl 5 has it.
> 
> ### Motivation
> 
> TSFC code is too explicit and clear, dynamic scoping would help to establish dependencies through the call stack that are not lexically explicit.