### PR TITLE
Revise FInAT interface

### DIFF
--- a/tests/test_create_finat_element.py
+++ b/tests/test_create_finat_element.py
@@ -8,7 +8,6 @@ from tsfc.finatinterface import create_element, supported_elements
 
 @pytest.fixture(params=["BDM",
                         "BDFM",
-                        "DRT",
                         "Lagrange",
                         "N1curl",
                         "N2curl",

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -22,6 +22,7 @@
 # along with FFC. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import, print_function, division
+from six import iteritems
 
 from singledispatch import singledispatch
 import weakref
@@ -75,7 +76,7 @@ def fiat_compat(element):
 
 
 @singledispatch
-def convert(element, shape_innermost=True):
+def convert(element, **kwargs):
     """Handler for converting UFL elements to FInAT elements.
 
     :arg element: The UFL element to convert.
@@ -89,7 +90,7 @@ def convert(element, shape_innermost=True):
 
 # Base finite elements first
 @convert.register(ufl.FiniteElement)
-def convert_finiteelement(element, shape_innermost=True):
+def convert_finiteelement(element, **kwargs):
     cell = as_fiat_cell(element.cell())
     if element.family() == "Quadrature":
         degree = element.degree()
@@ -97,7 +98,7 @@ def convert_finiteelement(element, shape_innermost=True):
         if degree is None or scheme is None:
             raise ValueError("Quadrature scheme and degree must be specified!")
 
-        return finat.QuadratureElement(cell, degree, scheme)
+        return finat.QuadratureElement(cell, degree, scheme), set()
     lmbda = supported_elements[element.family()]
     if lmbda is None:
         if element.cell().cellname() != "quadrilateral":
@@ -105,7 +106,8 @@ def convert_finiteelement(element, shape_innermost=True):
                              element.family())
         # Handle quadrilateral short names like RTCF and RTCE.
         element = element.reconstruct(cell=quad_tpc)
-        return finat.QuadrilateralElement(create_element(element, shape_innermost))
+        finat_elem, deps = _create_element(element, **kwargs)
+        return finat.QuadrilateralElement(finat_elem), deps
 
     kind = element.variant()
     if kind is None:
@@ -126,92 +128,119 @@ def convert_finiteelement(element, shape_innermost=True):
             lmbda = finat.GaussLegendre
         else:
             raise ValueError("Variant %r not supported on %s" % (kind, element.cell()))
-    return lmbda(cell, element.degree())
+    return lmbda(cell, element.degree()), set()
 
 
 # Element modifiers and compound element types
 @convert.register(ufl.BrokenElement)
-def convert_brokenelement(element, shape_innermost=True):
-    return finat.DiscontinuousElement(create_element(element._element, shape_innermost))
+def convert_brokenelement(element, **kwargs):
+    finat_elem, deps = _create_element(element._element, **kwargs)
+    return finat.DiscontinuousElement(finat_elem), deps
 
 
 @convert.register(ufl.EnrichedElement)
-def convert_enrichedelement(element, shape_innermost=True):
-    return finat.EnrichedElement([create_element(elem, shape_innermost)
-                                  for elem in element._elements])
+def convert_enrichedelement(element, **kwargs):
+    elements, deps = zip(*[_create_element(elem, **kwargs)
+                           for elem in element._elements])
+    return finat.EnrichedElement(elements), set.union(*deps)
 
 
 @convert.register(ufl.MixedElement)
-def convert_mixedelement(element, shape_innermost=True):
-    return finat.MixedElement([create_element(elem, shape_innermost)
-                               for elem in element.sub_elements()])
+def convert_mixedelement(element, **kwargs):
+    elements, deps = zip(*[_create_element(elem, **kwargs)
+                           for elem in element.sub_elements()])
+    return finat.MixedElement(elements), set.union(*deps)
 
 
 @convert.register(ufl.VectorElement)
-def convert_vectorelement(element, shape_innermost=True):
-    scalar_element = create_element(element.sub_elements()[0], shape_innermost)
-    return finat.TensorFiniteElement(scalar_element,
-                                     (element.num_sub_elements(),),
-                                     transpose=not shape_innermost)
+def convert_vectorelement(element, **kwargs):
+    scalar_elem, deps = _create_element(element.sub_elements()[0], **kwargs)
+    shape = (element.num_sub_elements(),)
+    shape_innermost = kwargs["shape_innermost"]
+    return (finat.TensorFiniteElement(scalar_elem, shape, not shape_innermost),
+            deps | {"shape_innermost"})
 
 
 @convert.register(ufl.TensorElement)
-def convert_tensorelement(element, shape_innermost=True):
-    scalar_element = create_element(element.sub_elements()[0], shape_innermost)
-    return finat.TensorFiniteElement(scalar_element,
-                                     element.reference_value_shape(),
-                                     transpose=not shape_innermost)
+def convert_tensorelement(element, **kwargs):
+    scalar_elem, deps = _create_element(element.sub_elements()[0], **kwargs)
+    shape = element.reference_value_shape()
+    shape_innermost = kwargs["shape_innermost"]
+    return (finat.TensorFiniteElement(scalar_elem, shape, not shape_innermost),
+            deps | {"shape_innermost"})
 
 
 @convert.register(ufl.TensorProductElement)
-def convert_tensorproductelement(element, shape_innermost=True):
+def convert_tensorproductelement(element, **kwargs):
     cell = element.cell()
     if type(cell) is not ufl.TensorProductCell:
         raise ValueError("TensorProductElement not on TensorProductCell?")
-    return finat.TensorProductElement([create_element(elem, shape_innermost)
-                                       for elem in element.sub_elements()])
+    elements, deps = zip(*[_create_element(elem, **kwargs)
+                           for elem in element.sub_elements()])
+    return finat.TensorProductElement(elements), set.union(*deps)
 
 
 @convert.register(ufl.HDivElement)
-def convert_hdivelement(element, shape_innermost=True):
-    return finat.HDivElement(create_element(element._element, shape_innermost))
+def convert_hdivelement(element, **kwargs):
+    finat_elem, deps = _create_element(element._element, **kwargs)
+    return finat.HDivElement(finat_elem), deps
 
 
 @convert.register(ufl.HCurlElement)
-def convert_hcurlelement(element, shape_innermost=True):
-    return finat.HCurlElement(create_element(element._element, shape_innermost))
+def convert_hcurlelement(element, **kwargs):
+    finat_elem, deps = _create_element(element._element, **kwargs)
+    return finat.HCurlElement(finat_elem), deps
 
 
 @convert.register(ufl.RestrictedElement)
-def convert_restrictedelement(element, shape_innermost=True):
+def convert_restrictedelement(element, **kwargs):
     # Fall back on FIAT
-    return fiat_compat(element)
+    return fiat_compat(element), set()
 
 
 quad_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval)
 _cache = weakref.WeakKeyDictionary()
 
 
-def create_element(element, shape_innermost=True):
+def create_element(ufl_element, shape_innermost=True):
     """Create a FInAT element (suitable for tabulating with) given a UFL element.
 
-    :arg element: The UFL element to create a FInAT element from.
+    :arg ufl_element: The UFL element to create a FInAT element from.
     :arg shape_innermost: Vector/tensor indices come after basis function indices
     """
-    try:
-        cache = _cache[element]
-    except KeyError:
-        _cache[element] = {}
-        cache = _cache[element]
+    finat_element, deps = _create_element(ufl_element,
+                                          shape_innermost=shape_innermost)
+    return finat_element
 
-    try:
-        return cache[shape_innermost]
-    except KeyError:
-        pass
 
-    if element.cell() is None:
+def _create_element(ufl_element, **kwargs):
+    """A caching wrapper around :py:func:`convert`.
+
+    Takes a UFL element and an unspecified set of parameter options,
+    and returns the converted element with the set of keyword names
+    that were relevant for conversion.
+    """
+    # Look up conversion in cache
+    try:
+        cache = _cache[ufl_element]
+    except KeyError:
+        _cache[ufl_element] = {}
+        cache = _cache[ufl_element]
+
+    for key, finat_element in iteritems(cache):
+        # Cache hit if all relevant parameter values match.
+        if all(kwargs[param] == value for param, value in key):
+            return finat_element, set(param for param, value in key)
+
+    # Convert if cache miss
+    if ufl_element.cell() is None:
         raise ValueError("Don't know how to build element when cell is not given")
 
-    finat_element = convert(element, shape_innermost=shape_innermost)
-    cache[shape_innermost] = finat_element
-    return finat_element
+    finat_element, deps = convert(ufl_element, **kwargs)
+
+    # Store conversion in cache
+    key = frozenset((param, kwargs[param]) for param in deps)
+    cache[key] = finat_element
+
+    # Forward result
+    return finat_element, deps

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -43,7 +43,7 @@ supported_elements = {
     "Bubble": finat.Bubble,
     "Crouzeix-Raviart": finat.CrouzeixRaviart,
     "Discontinuous Lagrange": finat.DiscontinuousLagrange,
-    "Discontinuous Raviart-Thomas": finat.DiscontinuousRaviartThomas,
+    "Discontinuous Raviart-Thomas": lambda c, d: finat.DiscontinuousElement(finat.RaviartThomas(c, d)),
     "Discontinuous Taylor": finat.DiscontinuousTaylor,
     "Gauss-Legendre": finat.GaussLegendre,
     "Gauss-Lobatto-Legendre": finat.GaussLobattoLegendre,

--- a/tsfc/kernel_interface/__init__.py
+++ b/tsfc/kernel_interface/__init__.py
@@ -24,7 +24,7 @@ class KernelInterface(with_metaclass(ABCMeta)):
         """Facet or vertex number as a GEM index."""
 
     @abstractmethod
-    def create_element(self, element):
+    def create_element(self, element, **kwargs):
         """Create a FInAT element (suitable for tabulating with) given
         a UFL element."""
 

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -91,10 +91,10 @@ class KernelBuilderBase(_KernelBuilderBase):
                 return True
         return False
 
-    def create_element(self, element):
+    def create_element(self, element, **kwargs):
         """Create a FInAT element (suitable for tabulating with) given
         a UFL element."""
-        return create_element(element)
+        return create_element(element, **kwargs)
 
 
 class ExpressionKernelBuilder(KernelBuilderBase):

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 from six.moves import range, zip
 
 import numpy
+import functools
 from itertools import chain, product
 
 import coffee.base as coffee
@@ -16,9 +17,8 @@ from tsfc.finatinterface import create_element as _create_element
 from tsfc.coffee import SCALAR_TYPE
 
 
-def create_element(element):
-    # UFC DoF ordering for vector/tensor elements is XXXX YYYY ZZZZ.
-    return _create_element(element, shape_innermost=False)
+# UFC DoF ordering for vector/tensor elements is XXXX YYYY ZZZZ.
+create_element = functools.partial(_create_element, shape_innermost=False)
 
 
 class KernelBuilder(KernelBuilderBase):
@@ -148,10 +148,10 @@ class KernelBuilder(KernelBuilderBase):
         # UFC tabulate_tensor always have cell orientations
         return True
 
-    def create_element(self, element):
+    def create_element(self, element, **kwargs):
         """Create a FInAT element (suitable for tabulating with) given
         a UFL element."""
-        return create_element(element)
+        return create_element(element, **kwargs)
 
 
 def prepare_coefficient(coefficient, num, name, interior_facet=False):

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -244,40 +244,6 @@ class PickRestriction(MultiFunction, ModifiedTerminalMixin):
             return o
 
 
-def _spanning_degree(cell, degree):
-    if cell is None:
-        assert degree == 0
-        return degree
-    elif cell.cellname() in ["interval", "triangle", "tetrahedron"]:
-        return degree
-    elif cell.cellname() == "quadrilateral":
-        # TODO: Tensor-product space assumed
-        return 2 * degree
-    elif isinstance(cell, ufl.TensorProductCell):
-        try:
-            # A component cell might be a quadrilateral, so recurse.
-            return sum(_spanning_degree(sub_cell, d)
-                       for sub_cell, d in zip(cell.sub_cells(), degree))
-        except TypeError:
-            assert degree == 0
-            return 0
-    else:
-        raise ValueError("Unknown cell %s" % cell.cellname())
-
-
-def spanning_degree(element):
-    """Determine the degree of the polynomial space spanning an element.
-
-    :arg element: The element to determine the degree of.
-
-    .. warning::
-
-       For non-simplex elements, this assumes a tensor-product
-       space.
-    """
-    return _spanning_degree(element.cell(), element.degree())
-
-
 def ufl_reuse_if_untouched(o, *ops):
     """Reuse object if operands are the same objects."""
     if all(a is b for a, b in zip(o.ufl_operands, ops)):


### PR DESCRIPTION
This pull request must be merged at the same time with FInAT/FInAT#39 which wraps a more complete set of FIAT elements. At the same FInAT interface will not have a generic fallback on the FIAT interface, such fallback only happens explicitly for `RestrictedElement`s and should happen for `NodalEnrichedElement`s (currently not translated) as well.

At the same time, we also revise UFL -> FInAT element conversion in anticipation of the changes required to use with runtime tabulated elements in Themis. This patch does not need dynamic scoping.
