### PR TITLE
Less CI testing with Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
   - pip install flake8
   - pip install flake8-future-import
   - pip install --upgrade pytest
-  - pip install --upgrade "numpy$NUMPY_VERSION"
 
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,6 @@ python:
   - "2.7"
   - "3.5"
 
-env:
-  - NUMPY_VERSION="==1.9.0"
-  - NUMPY_VERSION=">=1.10"
-
-matrix:
-  exclude:
-  - python: "3.5"
-  include:
-  - python: "3.5"
-    env: NUMPY_VERSION=">=1.10"
-
 before_install:
   - pip install -r requirements.txt
   - pip install flake8


### PR DESCRIPTION
Since Python 2.7 is no longer the primary target for TSFC, a single job in the build matrix should be enough for testing it.

@wence-, @tkarna: In light of #17, I wonder if we should still test with old numpy, but do so with Python 3 instead.