### PR TITLE
generates loopy kernels

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -2,3 +2,4 @@ git+https://github.com/coneoproject/COFFEE#egg=COFFEE
 git+https://github.com/firedrakeproject/ufl.git#egg=ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
+git+https://github.com/inducer/loopy.git#egg=loopy

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -2,4 +2,4 @@ git+https://github.com/coneoproject/COFFEE#egg=COFFEE
 git+https://github.com/firedrakeproject/ufl.git#egg=ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
---recursive git+https://github.com/firedrakeproject/loopy.git#egg=loopy
+git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -2,4 +2,4 @@ git+https://github.com/coneoproject/COFFEE#egg=COFFEE
 git+https://github.com/firedrakeproject/ufl.git#egg=ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
-git+https://gitlab.tiker.net/inducer/loopy.git#egg=loopy
+--recursive git+https://github.com/firedrakeproject/loopy.git#egg=loopy

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -2,4 +2,4 @@ git+https://github.com/coneoproject/COFFEE#egg=COFFEE
 git+https://github.com/firedrakeproject/ufl.git#egg=ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
-git+https://github.com/inducer/loopy.git#egg=loopy
+git+https://gitlab.tiker.net/inducer/loopy.git#egg=loopy

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -63,6 +63,13 @@ def test_idempotency(form):
 
     assert k1.ast.gencode() == k2.ast.gencode()
 
+    # Test loopy backend
+    import loopy
+    k1 = compile_form(form, coffee=False)[0]
+    k2 = compile_form(form, coffee=False)[0]
+
+    assert loopy.generate_code_v2(k1.ast).device_code() == loopy.generate_code_v2(k2.ast).device_code()
+
 
 if __name__ == "__main__":
     import os

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -23,18 +23,13 @@ class Bunch(object):
     pass
 
 
-def generate(impero_c, index_names, precision, scalar_type=None, roots=(), argument_indices=()):
+def generate(impero_c, index_names, precision, scalar_type=None):
     """Generates COFFEE code.
 
     :arg impero_c: ImperoC tuple with Impero AST and other data
     :arg index_names: pre-assigned index names
     :arg precision: floating-point precision for printing
     :arg scalar_type: type of scalars as C typename string
-    :arg roots: list of expression DAG roots for attaching
-        #pragma coffee expression
-    :arg argument_indices: argument indices for attaching
-        #pragma coffee linear loop
-        to the argument loops
     :returns: COFFEE function body
     """
     params = Bunch()
@@ -42,8 +37,6 @@ def generate(impero_c, index_names, precision, scalar_type=None, roots=(), argum
     params.indices = impero_c.indices
     params.precision = precision
     params.epsilon = 10.0 * eval("1e-%d" % precision)
-    params.roots = roots
-    params.argument_indices = argument_indices
     params.scalar_type = scalar_type or SCALAR_TYPE
 
     params.names = {}
@@ -88,12 +81,7 @@ def _ref_symbol(expr, parameters):
 
 
 def _root_pragma(expr, parameters):
-    """Decides whether to annonate the expression with
-    #pragma coffee expression"""
-    if expr in parameters.roots:
-        return "#pragma coffee expression"
-    else:
-        return None
+    return None
 
 
 @singledispatch
@@ -119,10 +107,6 @@ def statement_block(tree, parameters):
 
 @statement.register(imp.For)
 def statement_for(tree, parameters):
-    if tree.index in parameters.argument_indices:
-        pragma = "#pragma coffee linear loop"
-    else:
-        pragma = None
     extent = tree.index.extent
     assert extent
     i = _coffee_symbol(parameters.index_names[tree.index])
@@ -130,8 +114,7 @@ def statement_for(tree, parameters):
     return coffee.For(coffee.Decl("int", i, init=0),
                       coffee.Less(i, extent),
                       coffee.Incr(i, 1),
-                      statement(tree.children[0], parameters),
-                      pragma=pragma)
+                      statement(tree.children[0], parameters))
 
 
 @statement.register(imp.Initialise)

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -80,10 +80,6 @@ def _ref_symbol(expr, parameters):
     return _coffee_symbol(parameters.names[expr], rank=tuple(rank))
 
 
-def _root_pragma(expr, parameters):
-    return None
-
-
 @singledispatch
 def statement(tree, parameters):
     """Translates an Impero (sub)tree into a COFFEE AST corresponding
@@ -127,26 +123,20 @@ def statement_initialise(leaf, parameters):
 
 @statement.register(imp.Accumulate)
 def statement_accumulate(leaf, parameters):
-    pragma = _root_pragma(leaf.indexsum, parameters)
     return coffee.Incr(_ref_symbol(leaf.indexsum, parameters),
-                       expression(leaf.indexsum.children[0], parameters),
-                       pragma=pragma)
+                       expression(leaf.indexsum.children[0], parameters))
 
 
 @statement.register(imp.Return)
 def statement_return(leaf, parameters):
-    pragma = _root_pragma(leaf.expression, parameters)
     return coffee.Incr(expression(leaf.variable, parameters),
-                       expression(leaf.expression, parameters),
-                       pragma=pragma)
+                       expression(leaf.expression, parameters))
 
 
 @statement.register(imp.ReturnAccumulate)
 def statement_returnaccumulate(leaf, parameters):
-    pragma = _root_pragma(leaf.indexsum, parameters)
     return coffee.Incr(expression(leaf.variable, parameters),
-                       expression(leaf.indexsum.children[0], parameters),
-                       pragma=pragma)
+                       expression(leaf.indexsum.children[0], parameters))
 
 
 @statement.register(imp.Evaluate)

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -250,7 +250,7 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, co
     for multiindex, name in zip(argument_multiindices, ['j', 'k']):
         name_multiindex(multiindex, name)
 
-    return builder.construct_kernel(kernel_name, impero_c, parameters["precision"], parameters["scalar_type"], index_names, quad_rule)
+    return builder.construct_kernel(kernel_name, impero_c, parameters["precision"], index_names, quad_rule)
 
 
 def compile_expression_at_points(expression, points, coordinates, interface=None, parameters=None, coffee=True):
@@ -342,7 +342,7 @@ def compile_expression_at_points(expression, points, coordinates, interface=None
     # Handle kernel interface requirements
     builder.register_requirements([ir])
     # Build kernel tuple
-    return builder.construct_kernel(return_arg, impero_c, parameters["precision"], parameters["scalar_type"], {point_index: 'p'})
+    return builder.construct_kernel(return_arg, impero_c, parameters["precision"], {point_index: 'p'})
 
 
 def lower_integral_type(fiat_cell, integral_type):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -58,9 +58,9 @@ def compile_form(form, prefix="form", parameters=None, interface=None, coffee=Tr
 
     kernels = []
     if coffee:
-        interface = firedrake_interface_coffee
+        interface = firedrake_interface_coffee.KernelBuilder
     else:
-        interface = firedrake_interface_loopy
+        interface = firedrake_interface_loopy.KernelBuilder
     for integral_data in fd.integral_data:
         start = time.time()
         kernel = compile_integral(integral_data, fd, prefix, parameters, interface=interface)
@@ -89,7 +89,7 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface):
         _.update(parameters)
         parameters = _
     if interface is None:
-        interface = firedrake_interface.KernelBuilder
+        interface = firedrake_interface_loopy
 
     # Remove these here, they're handled below.
     if parameters.get("quadrature_degree") in ["auto", "default", None, -1, "-1"]:

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -89,7 +89,7 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface):
         _.update(parameters)
         parameters = _
     if interface is None:
-        interface = firedrake_interface_loopy
+        interface = firedrake_interface_loopy.KernelBuilder
 
     # Remove these here, they're handled below.
     if parameters.get("quadrature_degree") in ["auto", "default", None, -1, "-1"]:

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -250,7 +250,6 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, co
     for multiindex, name in zip(argument_multiindices, ['j', 'k']):
         name_multiindex(multiindex, name)
 
-
     return builder.construct_kernel(kernel_name, impero_c, parameters["precision"], parameters["scalar_type"], index_names, quad_rule)
 
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -2,6 +2,7 @@ import collections
 import operator
 import string
 import time
+import sys
 from functools import reduce
 from itertools import chain
 
@@ -29,6 +30,9 @@ from tsfc.parameters import default_parameters, is_complex
 
 import tsfc.kernel_interface.firedrake as firedrake_interface_coffee
 import tsfc.kernel_interface.firedrake_loopy as firedrake_interface_loopy
+
+# To handle big forms. The various transformations might need a deeper stack
+sys.setrecursionlimit(3000)
 
 
 def compile_form(form, prefix="form", parameters=None, interface=None, coffee=True):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -23,11 +23,6 @@ from finat.point_set import PointSet
 from finat.quadrature import AbstractQuadratureRule, make_quadrature
 
 from tsfc import fem, ufl_utils
-<<<<<<< HEAD
-from tsfc.coffee import generate as generate_coffee
-=======
-from tsfc.coffee import SCALAR_TYPE
->>>>>>> use loopy for expressions
 from tsfc.fiatinterface import as_fiat_cell
 from tsfc.logging import logger
 from tsfc.parameters import default_parameters, is_complex

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -23,7 +23,11 @@ from finat.point_set import PointSet
 from finat.quadrature import AbstractQuadratureRule, make_quadrature
 
 from tsfc import fem, ufl_utils
+<<<<<<< HEAD
 from tsfc.coffee import generate as generate_coffee
+=======
+from tsfc.coffee import SCALAR_TYPE
+>>>>>>> use loopy for expressions
 from tsfc.fiatinterface import as_fiat_cell
 from tsfc.logging import logger
 from tsfc.parameters import default_parameters, is_complex
@@ -257,7 +261,7 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface):
     return builder.construct_kernel(kernel_name, impero_c, parameters["precision"], parameters["scalar_type"], index_names)
 
 
-def compile_expression_at_points(expression, points, coordinates, parameters=None):
+def compile_expression_at_points(expression, points, coordinates, parameters=None, coffee=True):
     """Compiles a UFL expression to be evaluated at compile-time known
     reference points.  Useful for interpolating UFL expressions onto
     function spaces with only point evaluation nodes.
@@ -266,8 +270,10 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
     :arg points: reference coordinates of the evaluation points
     :arg coordinates: the coordinate function
     :arg parameters: parameters object
+    :arg coffee: compile coffee kernel instead of loopy kernel
     """
     import coffee.base as ast
+    import loopy as lp
 
     if parameters is None:
         parameters = default_parameters()
@@ -288,7 +294,10 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
                                                  complex_mode=complex_mode)
 
     # Initialise kernel builder
-    builder = firedrake_interface_coffee.ExpressionKernelBuilder(parameters["scalar_type"])
+    if coffee:
+        builder = firedrake_interface_coffee.ExpressionKernelBuilder(parameters["scalar_type"])
+    else:
+        builder = firedrake_interface_loopy.ExpressionKernelBuilder(parameters["scalar_type"])
 
     # Replace coordinates (if any)
     domain = expression.ufl_domain()
@@ -324,12 +333,15 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
     return_shape = (len(points),) + value_shape
     return_indices = point_set.indices + tensor_indices
     return_var = gem.Variable('A', return_shape)
-    return_arg = ast.Decl(parameters["scalar_type"], ast.Symbol('A', rank=return_shape))
+    if coffee:
+        return_arg = ast.Decl(parameters["scalar_type"], ast.Symbol('A', rank=return_shape))
+    else:
+        return_arg = lp.GlobalArg("A", dtype=parameters["scalar_type"], shape=return_shape)
+
     return_expr = gem.Indexed(return_var, return_indices)
     ir, = impero_utils.preprocess_gem([ir])
     impero_c = impero_utils.compile_gem([(return_expr, ir)], return_indices)
     point_index, = point_set.indices
-    body = generate_coffee(impero_c, {point_index: 'p'}, parameters["precision"], parameters["scalar_type"])
 
     # Handle cell orientations
     if builder.needs_cell_orientations([ir]):
@@ -338,7 +350,7 @@ def compile_expression_at_points(expression, points, coordinates, parameters=Non
     if builder.needs_cell_sizes([ir]):
         builder.require_cell_sizes()
     # Build kernel tuple
-    return builder.construct_kernel(return_arg, body)
+    return builder.construct_kernel(return_arg, impero_c, parameters["precision"], parameters["scalar_type"], {point_index: 'p'})
 
 
 def lower_integral_type(fiat_cell, integral_type):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -57,13 +57,9 @@ def compile_form(form, prefix="form", parameters=None, interface=None, coffee=Tr
     logger.info(GREEN % "compute_form_data finished in %g seconds.", time.time() - cpu_time)
 
     kernels = []
-    if coffee:
-        interface = firedrake_interface_coffee.KernelBuilder
-    else:
-        interface = firedrake_interface_loopy.KernelBuilder
     for integral_data in fd.integral_data:
         start = time.time()
-        kernel = compile_integral(integral_data, fd, prefix, parameters, interface=interface)
+        kernel = compile_integral(integral_data, fd, prefix, parameters, interface=interface, coffee=coffee)
         if kernel is not None:
             kernels.append(kernel)
         logger.info(GREEN % "compile_integral finished in %g seconds.", time.time() - start)
@@ -72,7 +68,7 @@ def compile_form(form, prefix="form", parameters=None, interface=None, coffee=Tr
     return kernels
 
 
-def compile_integral(integral_data, form_data, prefix, parameters, interface):
+def compile_integral(integral_data, form_data, prefix, parameters, interface, coffee):
     """Compiles a UFL integral into an assembly kernel.
 
     :arg integral_data: UFL integral data
@@ -89,7 +85,10 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface):
         _.update(parameters)
         parameters = _
     if interface is None:
-        interface = firedrake_interface_loopy.KernelBuilder
+        if coffee:
+            interface = firedrake_interface_coffee.KernelBuilder
+        else:
+            interface = firedrake_interface_loopy.KernelBuilder
 
     # Remove these here, they're handled below.
     if parameters.get("quadrature_degree") in ["auto", "default", None, -1, "-1"]:

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -13,6 +13,7 @@ from gem.optimise import remove_componenttensors as prune
 
 from tsfc.finatinterface import create_element
 from tsfc.kernel_interface.common import KernelBuilderBase as _KernelBuilderBase
+from tsfc.coffee import generate as generate_coffee
 
 
 # Expression kernel description type
@@ -273,16 +274,21 @@ class KernelBuilder(KernelBuilderBase):
         """Set that the kernel requires cell sizes."""
         self.kernel.needs_cell_sizes = True
 
-    def construct_kernel(self, name, body):
+    def construct_kernel(self, name, impero_c, precision, index_names):
         """Construct a fully built :class:`Kernel`.
 
         This function contains the logic for building the argument
         list for assembly kernels.
 
         :arg name: function name
-        :arg body: function body (:class:`coffee.Block` node)
+        :arg impero_c: ImperoC tuple with Impero AST and other data
+        :arg precision: floating-point precision for printing
+        :arg index_names: pre-assigned index names
         :returns: :class:`Kernel` object
         """
+
+        body = generate_coffee(impero_c, index_names, precision)
+
         args = [self.local_tensor, self.coordinates_arg]
         if self.kernel.oriented:
             args.append(cell_orientations_coffee_arg)

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -173,7 +173,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
 
         from tsfc.coffee import generate as generate_coffee
 
-        args = [return_arg] + self.kernel_args
+        args = [return_arg]
         if self.oriented:
             args.append(cell_orientations_coffee_arg)
         if self.cell_sizes:

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -163,19 +163,24 @@ class ExpressionKernelBuilder(KernelBuilderBase):
     def require_cell_sizes(self):
         self.cell_sizes = True
 
-    def construct_kernel(self, return_arg, body):
+    def construct_kernel(self, return_arg, impero_c, precision, index_names):
         """Constructs an :class:`ExpressionKernel`.
 
         :arg return_arg: COFFEE argument for the return value
         :arg body: function body (:class:`coffee.Block` node)
         :returns: :class:`ExpressionKernel` object
         """
-        args = [return_arg]
+
+        from tsfc.coffee import generate as generate_coffee
+
+        args = [return_arg] + self.kernel_args
         if self.oriented:
             args.append(cell_orientations_coffee_arg)
         if self.cell_sizes:
             args.append(self.cell_sizes_arg)
         args.extend(self.kernel_args)
+
+        body = generate_coffee(impero_c, index_names, precision)
 
         kernel_code = super(ExpressionKernelBuilder, self).construct_kernel("expression_kernel", args, body)
         return ExpressionKernel(kernel_code, self.oriented, self.cell_sizes, self.coefficients)

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -261,7 +261,7 @@ class KernelBuilder(KernelBuilderBase):
         knl = self.kernel
         knl.oriented, knl.needs_cell_sizes, knl.tabulations = check_requirements(ir)
 
-    def construct_kernel(self, name, impero_c, precision, scalar_type, index_names, quadrature_rule):
+    def construct_kernel(self, name, impero_c, precision, index_names, quadrature_rule):
         """Construct a fully built :class:`Kernel`.
 
         This function contains the logic for building the argument
@@ -270,13 +270,12 @@ class KernelBuilder(KernelBuilderBase):
         :arg name: function name
         :arg impero_c: ImperoC tuple with Impero AST and other data
         :arg precision: floating-point precision for printing
-        :arg scalar_type: type of scalars as C typename string
         :arg index_names: pre-assigned index names
         :arg quadrature rule: quadrature rule
 
         :returns: :class:`Kernel` object
         """
-        body = generate_coffee(impero_c, index_names, precision, scalar_type)
+        body = generate_coffee(impero_c, index_names, precision, self.scalar_type)
 
         args = [self.local_tensor, self.coordinates_arg]
         if self.kernel.oriented:

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -153,9 +153,6 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         :arg body: function body (:class:`coffee.Block` node)
         :returns: :class:`ExpressionKernel` object
         """
-
-        from tsfc.coffee import generate as generate_coffee
-
         args = [return_arg]
         if self.oriented:
             args.append(cell_orientations_coffee_arg)
@@ -279,7 +276,6 @@ class KernelBuilder(KernelBuilderBase):
 
         :returns: :class:`Kernel` object
         """
-
         body = generate_coffee(impero_c, index_names, precision, scalar_type)
 
         args = [self.local_tensor, self.coordinates_arg]

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -279,7 +279,7 @@ class KernelBuilder(KernelBuilderBase):
         """Set that the kernel requires cell sizes."""
         self.kernel.needs_cell_sizes = True
 
-    def construct_kernel(self, name, impero_c, precision, index_names):
+    def construct_kernel(self, name, impero_c, precision, scalar_type, index_names):
         """Construct a fully built :class:`Kernel`.
 
         This function contains the logic for building the argument
@@ -289,10 +289,11 @@ class KernelBuilder(KernelBuilderBase):
         :arg impero_c: ImperoC tuple with Impero AST and other data
         :arg precision: floating-point precision for printing
         :arg index_names: pre-assigned index names
+        :arg scalar_type: type of scalars as C typename string
         :returns: :class:`Kernel` object
         """
 
-        body = generate_coffee(impero_c, index_names, precision)
+        body = generate_coffee(impero_c, index_names, precision, scalar_type)
 
         args = [self.local_tensor, self.coordinates_arg]
         if self.kernel.oriented:

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -1,0 +1,356 @@
+from __future__ import absolute_import, print_function, division
+
+import numpy
+from collections import namedtuple
+from itertools import chain, product
+
+from ufl import Coefficient, MixedElement as ufl_MixedElement, FunctionSpace
+
+import gem
+from gem.node import traversal
+from gem.optimise import remove_componenttensors as prune
+
+import loopy as lp
+
+from tsfc.finatinterface import create_element
+from tsfc.kernel_interface.common import KernelBuilderBase as _KernelBuilderBase
+from tsfc.parameters import SCALAR_TYPE
+from tsfc.loopy import generate as generate_loopy
+
+
+# Expression kernel description type
+ExpressionKernel = namedtuple('ExpressionKernel', ['ast', 'oriented', 'coefficients'])
+
+
+class Kernel(object):
+    __slots__ = ("ast", "integral_type", "oriented", "subdomain_id",
+                 "domain_number", "coefficient_numbers", "__weakref__")
+    """A compiled Kernel object.
+
+    :kwarg ast: The loopy kernel object.
+    :kwarg integral_type: The type of integral.
+    :kwarg oriented: Does the kernel require cell_orientations.
+    :kwarg subdomain_id: What is the subdomain id for this kernel.
+    :kwarg domain_number: Which domain number in the original form
+        does this kernel correspond to (can be used to index into
+        original_form.ufl_domains() to get the correct domain).
+    :kwarg coefficient_numbers: A list of which coefficients from the
+        form the kernel needs.
+    """
+    def __init__(self, ast=None, integral_type=None, oriented=False,
+                 subdomain_id=None, domain_number=None,
+                 coefficient_numbers=()):
+        # Defaults
+        self.ast = ast
+        self.integral_type = integral_type
+        self.oriented = oriented
+        self.domain_number = domain_number
+        self.subdomain_id = subdomain_id
+        self.coefficient_numbers = coefficient_numbers
+        super(Kernel, self).__init__()
+
+
+class KernelBuilderBase(_KernelBuilderBase):
+
+    def __init__(self, interior_facet=False):
+        """Initialise a kernel builder.
+
+        :arg interior_facet: kernel accesses two cells
+        """
+        super(KernelBuilderBase, self).__init__(interior_facet=interior_facet)
+
+        # Cell orientation
+        if self.interior_facet:
+            shape = (2,)
+            cell_orientations = gem.Variable("cell_orientations", shape)
+            self._cell_orientations = (gem.Indexed(cell_orientations, (0,)),
+                                       gem.Indexed(cell_orientations, (1,)))
+        else:
+            shape = (1,)
+            cell_orientations = gem.Variable("cell_orientations", shape)
+            self._cell_orientations = (gem.Indexed(cell_orientations, (0,)),)
+        self.cell_orientations_loopy_arg = lp.GlobalArg("cell_orientations", dtype=numpy.int32, shape=shape)
+
+    def _coefficient(self, coefficient, name):
+        """Prepare a coefficient. Adds glue code for the coefficient
+        and adds the coefficient to the coefficient map.
+
+        :arg coefficient: :class:`ufl.Coefficient`
+        :arg name: coefficient name
+        :returns: loopy argument for the coefficient
+        """
+        funarg, expression = prepare_coefficient(coefficient, name, interior_facet=self.interior_facet)
+        self.coefficient_map[coefficient] = expression
+        return funarg
+
+    @staticmethod
+    def needs_cell_orientations(ir):
+        """Does a multi-root GEM expression DAG references cell
+        orientations?"""
+        for node in traversal(ir):
+            if isinstance(node, gem.Variable) and node.name == "cell_orientations":
+                return True
+        return False
+
+    def create_element(self, element, **kwargs):
+        """Create a FInAT element (suitable for tabulating with) given
+        a UFL element."""
+        return create_element(element, **kwargs)
+
+
+class ExpressionKernelBuilder(KernelBuilderBase):
+    """Builds expression kernels for UFL interpolation in Firedrake."""
+
+    def __init__(self):
+        super(ExpressionKernelBuilder, self).__init__()
+        self.oriented = False
+
+    def set_coefficients(self, coefficients):
+        """Prepare the coefficients of the expression.
+
+        :arg coefficients: UFL coefficients from Firedrake
+        """
+        self.coefficients = []  # Firedrake coefficients for calling the kernel
+        self.coefficient_split = {}
+        self.kernel_args = []
+
+        for i, coefficient in enumerate(coefficients):
+            if type(coefficient.ufl_element()) == ufl_MixedElement:
+                subcoeffs = coefficient.split()  # Firedrake-specific
+                self.coefficients.extend(subcoeffs)
+                self.coefficient_split[coefficient] = subcoeffs
+                self.kernel_args += [self._coefficient(subcoeff, "w_%d_%d" % (i, j))
+                                     for j, subcoeff in enumerate(subcoeffs)]
+            else:
+                self.coefficients.append(coefficient)
+                self.kernel_args.append(self._coefficient(coefficient, "w_%d" % (i,)))
+
+    def require_cell_orientations(self):
+        """Set that the kernel requires cell orientations."""
+        self.oriented = True
+
+    def construct_kernel(self, return_arg, impero_c, precision):
+        """Constructs an :class:`ExpressionKernel`.
+
+        :arg return_arg: loopy.GlobalArg for the return value
+        :arg impero_c: gem.ImperoC object that represents the kernel
+        :arg precision: floating point precision for code generation
+        :returns: :class:`ExpressionKernel` object
+        """
+        args = [return_arg] + self.kernel_args
+        if self.oriented:
+            args.insert(1, self.cell_orientations_loopy_arg)
+
+        loopy_kernel = generate_loopy(impero_c, args, precision, "expression_kernel")
+        return ExpressionKernel(loopy_kernel, self.oriented, self.coefficients)
+
+
+class KernelBuilder(KernelBuilderBase):
+    """Helper class for building a :class:`Kernel` object."""
+
+    def __init__(self, integral_type, subdomain_id, domain_number):
+        """Initialise a kernel builder."""
+        super(KernelBuilder, self).__init__(integral_type.startswith("interior_facet"))
+
+        self.kernel = Kernel(integral_type=integral_type, subdomain_id=subdomain_id,
+                             domain_number=domain_number)
+        self.local_tensor = None
+        self.coordinates_arg = None
+        self.coefficient_args = []
+        self.coefficient_split = {}
+
+        # Facet number
+        if integral_type in ['exterior_facet', 'exterior_facet_vert']:
+            facet = gem.Variable('facet', (1,))
+            self._entity_number = {None: gem.VariableIndex(gem.Indexed(facet, (0,)))}
+        elif integral_type in ['interior_facet', 'interior_facet_vert']:
+            facet = gem.Variable('facet', (2,))
+            self._entity_number = {
+                '+': gem.VariableIndex(gem.Indexed(facet, (0,))),
+                '-': gem.VariableIndex(gem.Indexed(facet, (1,)))
+            }
+        elif integral_type == 'interior_facet_horiz':
+            self._entity_number = {'+': 1, '-': 0}
+
+    def set_arguments(self, arguments, multiindices):
+        """Process arguments.
+
+        :arg arguments: :class:`ufl.Argument`s
+        :arg multiindices: GEM argument multiindices
+        :returns: GEM expression representing the return variable
+        """
+        self.local_tensor, expressions = prepare_arguments(
+            arguments, multiindices, interior_facet=self.interior_facet)
+        return expressions
+
+    def set_coordinates(self, domain):
+        """Prepare the coordinate field.
+
+        :arg domain: :class:`ufl.Domain`
+        """
+        # Create a fake coordinate coefficient for a domain.
+        f = Coefficient(FunctionSpace(domain, domain.ufl_coordinate_element()))
+        self.domain_coordinate[domain] = f
+        self.coordinates_arg = self._coefficient(f, "coords")
+
+    def set_coefficients(self, integral_data, form_data):
+        """Prepare the coefficients of the form.
+
+        :arg integral_data: UFL integral data
+        :arg form_data: UFL form data
+        """
+        coefficients = []
+        coefficient_numbers = []
+        # enabled_coefficients is a boolean array that indicates which
+        # of reduced_coefficients the integral requires.
+        for i in range(len(integral_data.enabled_coefficients)):
+            if integral_data.enabled_coefficients[i]:
+                coefficient = form_data.function_replace_map[form_data.reduced_coefficients[i]]
+                if type(coefficient.ufl_element()) == ufl_MixedElement:
+                    split = [Coefficient(FunctionSpace(coefficient.ufl_domain(), element))
+                             for element in coefficient.ufl_element().sub_elements()]
+                    coefficients.extend(split)
+                    self.coefficient_split[coefficient] = split
+                else:
+                    coefficients.append(coefficient)
+                # This is which coefficient in the original form the
+                # current coefficient is.
+                # Consider f*v*dx + g*v*ds, the full form contains two
+                # coefficients, but each integral only requires one.
+                coefficient_numbers.append(form_data.original_coefficient_positions[i])
+        for i, coefficient in enumerate(coefficients):
+            self.coefficient_args.append(
+                self._coefficient(coefficient, "w_%d" % i))
+        self.kernel.coefficient_numbers = tuple(coefficient_numbers)
+
+    def require_cell_orientations(self):
+        """Set that the kernel requires cell orientations."""
+        self.kernel.oriented = True
+
+    def construct_kernel(self, name, impero_c, precision, index_names):
+        """Construct a fully built :class:`Kernel`.
+
+        This function contains the logic for building the argument
+        list for assembly kernels.
+
+        :arg name: function name
+        :arg impero_c: ImperoC tuple with Impero AST and other data
+        :arg precision: floating-point precision for printing
+        :arg index_names: pre-assigned index names
+        :returns: :class:`Kernel` object
+        """
+
+        args = [self.local_tensor, self.coordinates_arg]
+        if self.kernel.oriented:
+            args.append(self.cell_orientations_loopy_arg)
+        args.extend(self.coefficient_args)
+        if self.kernel.integral_type in ["exterior_facet", "exterior_facet_vert"]:
+            args.append(lp.GlobalArg("facet", dtype=numpy.uint32, shape=(1,)))
+        elif self.kernel.integral_type in ["interior_facet", "interior_facet_vert"]:
+            args.append(lp.GlobalArg("facet", dtype=numpy.uint32, shape=(2,)))
+
+        self.kernel.ast = generate_loopy(impero_c, args, precision, name, index_names)
+        return self.kernel
+
+    def construct_empty_kernel(self, name):
+        """Return None, since Firedrake needs no empty kernels.
+
+        :arg name: function name
+        :returns: None
+        """
+        return None
+
+    def get_loopy_arguments(self):
+        args = [self.local_tensor, self.coordinates_arg]
+        if self.kernel.oriented:
+            args.append(self.cell_orientations_loopy_arg)
+        args.extend(self.coefficient_args)
+        if self.kernel.integral_type in ["exterior_facet", "exterior_facet_vert"]:
+            args.append(lp.GlobalArg("facet", dtype=numpy.uint32, shape=(1,)))
+        elif self.kernel.integral_type in ["interior_facet", "interior_facet_vert"]:
+            args.append(lp.GlobalArg("facet", dtype=numpy.uint32, shape=(2,)))
+
+
+def prepare_coefficient(coefficient, name, interior_facet=False):
+    """Bridges the kernel interface and the GEM abstraction for
+    Coefficients.
+
+    :arg coefficient: UFL Coefficient
+    :arg name: unique name to refer to the Coefficient in the kernel
+    :arg interior_facet: interior facet integral?
+    :returns: (funarg, expression)
+         funarg     - :class:`loopy.GlobalArg` function argument
+         expression - GEM expression referring to the Coefficient
+                      values
+    """
+    assert isinstance(interior_facet, bool)
+
+    if coefficient.ufl_element().family() == 'Real':
+        # Constant
+        funarg = lp.GlobalArg(name, dtype=SCALAR_TYPE, shape=(coefficient.ufl_element().value_size(),))
+        expression = gem.reshape(gem.Variable(name, (None,)),
+                                 coefficient.ufl_shape)
+
+        return funarg, expression
+
+    finat_element = create_element(coefficient.ufl_element())
+
+    shape = finat_element.index_shape
+    size = numpy.prod(shape, dtype=int)
+
+    if not interior_facet:
+        expression = gem.reshape(gem.Variable(name, (size,)), shape)
+    else:
+        varexp = gem.Variable(name, (2*size,))
+        plus = gem.view(varexp, slice(size))
+        minus = gem.view(varexp, slice(size, 2*size))
+        expression = (gem.reshape(plus, shape), gem.reshape(minus, shape))
+        size = size * 2
+    funarg = lp.GlobalArg(name, dtype=SCALAR_TYPE, shape=(size,))
+    return funarg, expression
+
+
+def prepare_arguments(arguments, multiindices, interior_facet=False):
+    """Bridges the kernel interface and the GEM abstraction for
+    Arguments.  Vector Arguments are rearranged here for interior
+    facet integrals.
+
+    :arg arguments: UFL Arguments
+    :arg multiindices: Argument multiindices
+    :arg interior_facet: interior facet integral?
+    :returns: (funarg, expression)
+         funarg      - :class:`loopy.GlobalArg` function argument
+         expressions - GEM expressions referring to the argument
+                       tensor
+    """
+
+    assert isinstance(interior_facet, bool)
+
+    if len(arguments) == 0:
+        # No arguments
+        funarg = lp.GlobalArg("A", dtype=SCALAR_TYPE, shape=(1,))
+        expression = gem.Indexed(gem.Variable("A", (1,)), (0,))
+
+        return funarg, [expression]
+
+    elements = tuple(create_element(arg.ufl_element()) for arg in arguments)
+    shapes = tuple(element.index_shape for element in elements)
+
+    def expression(restricted):
+        return gem.Indexed(gem.reshape(restricted, *shapes),
+                           tuple(chain(*multiindices)))
+
+    u_shape = numpy.array([numpy.prod(shape, dtype=int) for shape in shapes])
+    if interior_facet:
+        c_shape = tuple(2 * u_shape)
+        slicez = [[slice(r * s, (r + 1) * s)
+                   for r, s in zip(restrictions, u_shape)]
+                  for restrictions in product((0, 1), repeat=len(arguments))]
+    else:
+        c_shape = tuple(u_shape)
+        slicez = [[slice(s) for s in u_shape]]
+
+    funarg = lp.GlobalArg("A", dtype=SCALAR_TYPE, shape=c_shape)
+    varexp = gem.Variable("A", c_shape)
+    expressions = [expression(gem.view(varexp, *slices)) for slices in slicez]
+    return funarg, prune(expressions)

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -1,6 +1,7 @@
 import numpy
 from collections import namedtuple
 from itertools import chain, product
+from functools import partial
 
 from ufl import Coefficient, MixedElement as ufl_MixedElement, FunctionSpace, FiniteElement
 
@@ -18,6 +19,10 @@ from tsfc.loopy import generate as generate_loopy
 
 # Expression kernel description type
 ExpressionKernel = namedtuple('ExpressionKernel', ['ast', 'oriented', 'needs_cell_sizes', 'coefficients'])
+
+
+def make_builder(*args, **kwargs):
+    return partial(KernelBuilder, *args, **kwargs)
 
 
 class Kernel(object):
@@ -186,7 +191,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
 class KernelBuilder(KernelBuilderBase):
     """Helper class for building a :class:`Kernel` object."""
 
-    def __init__(self, integral_type, subdomain_id, domain_number, scalar_type=None):
+    def __init__(self, integral_type, subdomain_id, domain_number, scalar_type=None, dont_split=()):
         """Initialise a kernel builder."""
         super(KernelBuilder, self).__init__(scalar_type, integral_type.startswith("interior_facet"))
 
@@ -196,6 +201,7 @@ class KernelBuilder(KernelBuilderBase):
         self.coordinates_arg = None
         self.coefficient_args = []
         self.coefficient_split = {}
+        self.dont_split = frozenset(dont_split)
 
         # Facet number
         if integral_type in ['exterior_facet', 'exterior_facet_vert']:
@@ -243,12 +249,17 @@ class KernelBuilder(KernelBuilderBase):
         # of reduced_coefficients the integral requires.
         for i in range(len(integral_data.enabled_coefficients)):
             if integral_data.enabled_coefficients[i]:
-                coefficient = form_data.function_replace_map[form_data.reduced_coefficients[i]]
+                original = form_data.reduced_coefficients[i]
+                coefficient = form_data.function_replace_map[original]
                 if type(coefficient.ufl_element()) == ufl_MixedElement:
-                    split = [Coefficient(FunctionSpace(coefficient.ufl_domain(), element))
-                             for element in coefficient.ufl_element().sub_elements()]
-                    coefficients.extend(split)
-                    self.coefficient_split[coefficient] = split
+                    if original in self.dont_split:
+                        coefficients.append(coefficient)
+                        self.coefficient_split[coefficient] = [coefficient]
+                    else:
+                        split = [Coefficient(FunctionSpace(coefficient.ufl_domain(), element))
+                                 for element in coefficient.ufl_element().sub_elements()]
+                        coefficients.extend(split)
+                        self.coefficient_split[coefficient] = split
                 else:
                     coefficients.append(coefficient)
                 # This is which coefficient in the original form the

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -258,16 +258,6 @@ class KernelBuilder(KernelBuilderBase):
         """
         return None
 
-    def get_loopy_arguments(self):
-        args = [self.local_tensor, self.coordinates_arg]
-        if self.kernel.oriented:
-            args.append(self.cell_orientations_loopy_arg)
-        args.extend(self.coefficient_args)
-        if self.kernel.integral_type in ["exterior_facet", "exterior_facet_vert"]:
-            args.append(lp.GlobalArg("facet", dtype=numpy.uint32, shape=(1,)))
-        elif self.kernel.integral_type in ["interior_facet", "interior_facet_vert"]:
-            args.append(lp.GlobalArg("facet", dtype=numpy.uint32, shape=(2,)))
-
 
 def prepare_coefficient(coefficient, name, interior_facet=False):
     """Bridges the kernel interface and the GEM abstraction for

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -162,11 +162,11 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         if self.cell_sizes:
             args.append(self.cell_sizes_arg)
         args.extend(self.kernel_args)
-        for name_, shape in self.kernel.tabulations:
+        for name_, shape in self.tabulations:
             args.append(lp.GlobalArg(name_, dtype=self.scalar_type, shape=shape))
 
         loopy_kernel = generate_loopy(impero_c, args, precision, "expression_kernel", index_names, self.scalar_type)
-        return ExpressionKernel(loopy_kernel, self.oriented, self.cell_sizes, self.coefficients)
+        return ExpressionKernel(loopy_kernel, self.oriented, self.cell_sizes, self.coefficients, self.tabulations)
 
 
 class KernelBuilder(KernelBuilderBase):
@@ -259,7 +259,7 @@ class KernelBuilder(KernelBuilderBase):
         knl = self.kernel
         knl.oriented, knl.needs_cell_sizes, knl.tabulations = check_requirements(ir)
 
-    def construct_kernel(self, name, impero_c, precision, scalar_type, index_names, quadrature_rule):
+    def construct_kernel(self, name, impero_c, precision, index_names, quadrature_rule):
         """Construct a fully built :class:`Kernel`.
 
         This function contains the logic for building the argument
@@ -268,7 +268,6 @@ class KernelBuilder(KernelBuilderBase):
         :arg name: function name
         :arg impero_c: ImperoC tuple with Impero AST and other data
         :arg precision: floating-point precision for printing
-        :arg scalar_type: type of scalars as C typename string
         :arg index_names: pre-assigned index names
         :returns: :class:`Kernel` object
         """

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function, division
-
 import numpy
 from collections import namedtuple
 from itertools import chain, product

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -127,19 +127,20 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         """Set that the kernel requires cell orientations."""
         self.oriented = True
 
-    def construct_kernel(self, return_arg, impero_c, precision):
+    def construct_kernel(self, return_arg, impero_c, precision, index_names):
         """Constructs an :class:`ExpressionKernel`.
 
         :arg return_arg: loopy.GlobalArg for the return value
         :arg impero_c: gem.ImperoC object that represents the kernel
         :arg precision: floating point precision for code generation
+        :arg index_names: pre-assigned index names
         :returns: :class:`ExpressionKernel` object
         """
         args = [return_arg] + self.kernel_args
         if self.oriented:
             args.insert(1, self.cell_orientations_loopy_arg)
 
-        loopy_kernel = generate_loopy(impero_c, args, precision, "expression_kernel")
+        loopy_kernel = generate_loopy(impero_c, args, precision, "expression_kernel", index_names)
         return ExpressionKernel(loopy_kernel, self.oriented, self.coefficients)
 
 

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -102,7 +102,23 @@ class KernelBuilder(KernelBuilderBase):
             expression = prepare_coefficient(coefficient, n, name, self.interior_facet)
             self.coefficient_map[coefficient] = expression
 
-    def construct_kernel(self, name, body):
+    def construct_kernel(self, name, impero_c, precision, index_names):
+        """Construct a fully built kernel function.
+
+        This function contains the logic for building the argument
+        list for assembly kernels.
+
+        :arg name: function name
+        :arg impero_c: ImperoC tuple with Impero AST and other data
+        :arg precision: floating-point precision for printing
+        :arg index_names: pre-assigned index names
+        :returns: a COFFEE function definition object
+        """
+        from tsfc.coffee import generate as generate_coffee
+        body = generate_coffee(impero_c, index_names, precision)
+        return self._construct_kernel_from_body(name, body)
+
+    def _construct_kernel_from_body(self, name, body):
         """Construct a fully built kernel function.
 
         This function contains the logic for building the argument
@@ -143,7 +159,7 @@ class KernelBuilder(KernelBuilderBase):
         :returns: a COFFEE function definition object
         """
         body = coffee.Block([])  # empty block
-        return self.construct_kernel(name, body)
+        return self._construct_kernel_from_body(name, body)
 
     @staticmethod
     def require_cell_orientations():

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -22,7 +22,7 @@ create_element = functools.partial(_create_element, shape_innermost=False)
 class KernelBuilder(KernelBuilderBase):
     """Helper class for building a :class:`Kernel` object."""
 
-    def __init__(self, integral_type, subdomain_id, domain_number, scalar_type):
+    def __init__(self, integral_type, subdomain_id, domain_number, scalar_type=None):
         """Initialise a kernel builder."""
         super(KernelBuilder, self).__init__(scalar_type, integral_type.startswith("interior_facet"))
         self.integral_type = integral_type
@@ -116,7 +116,7 @@ class KernelBuilder(KernelBuilderBase):
         :returns: a COFFEE function definition object
         """
         from tsfc.coffee import generate as generate_coffee
-        body = generate_coffee(impero_c, index_names, precision)
+        body = generate_coffee(impero_c, index_names, precision, scalar_type=self.scalar_type)
         return self._construct_kernel_from_body(name, body)
 
     def _construct_kernel_from_body(self, name, body, quadrature_rule):

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function, division
 from math import isnan
 
 import numpy
-from singledispatch import singledispatch
+from functools import singledispatch
 from collections import defaultdict, OrderedDict
 
 from gem import gem, impero as imp

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -1,0 +1,347 @@
+"""Generate loopy Loop from ImperoC tuple data.
+
+This is the final stage of code generation in TSFC."""
+
+from __future__ import absolute_import, print_function, division
+
+from math import isnan
+
+import numpy
+from singledispatch import singledispatch
+from collections import defaultdict, OrderedDict
+
+from gem import gem, impero as imp
+
+import islpy as isl
+import loopy as lp
+
+import pymbolic.primitives as p
+
+from pytools import UniqueNameGenerator
+
+
+class LoopyContext(object):
+    def __init__(self):
+        self.indices = {}
+        self.active_indices = {}  # gem index -> pymbolic variable
+        self.index_extent = OrderedDict()  # pymbolic variable for indices - > extent
+        self.gem_to_pymbolic = {}  # gem node -> pymbolic variable
+        self.name_gen = UniqueNameGenerator()
+
+    def pym_multiindex(self, multiindex):
+        rank = []
+        for index in multiindex:
+            if isinstance(index, gem.Index):
+                rank.append(self.active_indices[index])
+            elif isinstance(index, gem.VariableIndex):
+                rank.append(expression(index.expression, self))
+            else:
+                assert isinstance(index, int)
+                rank.append(index)
+        return tuple(rank)
+
+    def pymbolic_variable(self, node):
+        try:
+            pym = self.gem_to_pymbolic[node]
+        except KeyError:
+            name = self.name_gen(node.name)
+            pym = p.Variable(name)
+            self.gem_to_pymbolic[node] = pym
+        if node in self.indices:
+            rank = self.pym_multiindex(self.indices[node])
+            if rank:
+                return p.Subscript(pym, rank)
+            else:
+                return pym
+        else:
+            return pym
+
+    def active_inames(self):
+        # Return all active indices
+        return frozenset([i.name for i in self.active_indices.values()])
+
+
+def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=[]):
+    """Generates loopy code.
+
+    :arg impero_c: ImperoC tuple with Impero AST and other data
+    :arg args: list of loopy.GlobalArgs
+    :arg precision: floating-point precision for printing
+    :arg kernel_name: function name of the kernel
+    :arg index_names: pre-assigned index names
+    :returns: loopy kernel
+    """
+    ctx = LoopyContext()
+    ctx.indices = impero_c.indices
+    ctx.index_names = defaultdict(lambda: "i", index_names)
+    ctx.precision = precision
+    ctx.epsilon = 10.0 ** (-precision)
+
+    data = list(args)
+    for i, temp in enumerate(impero_c.temporaries):
+        name = "t%d" % i
+        if isinstance(temp, gem.Constant):
+            data.append(lp.TemporaryVariable(name, shape=temp.shape, dtype=temp.array.dtype, initializer=temp.array, scope=lp.temp_var_scope.LOCAL, read_only=True))
+        else:
+            shape = tuple([i.extent for i in ctx.indices[temp]]) + temp.shape
+            data.append(lp.TemporaryVariable(name, shape=shape, dtype=numpy.float64, initializer=None, scope=lp.temp_var_scope.LOCAL, read_only=False))
+        ctx.gem_to_pymbolic[temp] = p.Variable(name)
+
+    instructions = statement(impero_c.tree, ctx)
+
+    domains = []
+
+    for idx, extent in ctx.index_extent.items():
+        inames = isl.make_zero_and_vars([idx])
+        domains.append(((inames[0].le_set(inames[idx])) & (inames[idx].lt_set(inames[0] + extent))))
+
+    if not domains:
+        domains = [isl.BasicSet("[] -> {[]}")]
+
+    knl = lp.make_kernel(domains, instructions, data, name=kernel_name, target=lp.CTarget(), seq_dependencies=True)
+    # print(knl)
+    # iname_tag = dict((i, 'ord') for i in knl.all_inames())
+    # knl = lp.tag_inames(knl, iname_tag)
+    return knl
+
+
+@singledispatch
+def statement(tree, ctx):
+    """Translates an Impero (sub)tree into a loopy instructions corresponding
+    to a C statement.
+
+    :arg tree: Impero (sub)tree
+    :arg ctx: miscellaneous code generation data
+    :returns: list of loopy instructions
+    """
+    raise AssertionError("cannot generate loopy from %s" % type(tree))
+
+
+@statement.register(imp.Block)
+def statement_block(tree, ctx):
+    statements = []
+    for child in tree.children:
+        statements.extend(statement(child, ctx))
+    return statements
+
+
+@statement.register(imp.For)
+def statement_for(tree, ctx):
+    extent = tree.index.extent
+    assert extent
+    idx = ctx.name_gen(ctx.index_names[tree.index])
+    ctx.active_indices[tree.index] = p.Variable(idx)
+    ctx.index_extent[idx] = extent
+
+    statements = statement(tree.children[0], ctx)
+
+    ctx.active_indices.pop(tree.index)
+    return statements
+
+
+@statement.register(imp.Initialise)
+def statement_initialise(leaf, ctx):
+    return [lp.Assignment(expression(leaf.indexsum, ctx), 0.0, within_inames=ctx.active_inames())]
+
+
+@statement.register(imp.Accumulate)
+def statement_accumulate(leaf, ctx):
+    lhs = expression(leaf.indexsum, ctx)
+    rhs = lhs + expression(leaf.indexsum.children[0], ctx)
+    return [lp.Assignment(lhs, rhs, within_inames=ctx.active_inames())]
+
+
+@statement.register(imp.Return)
+def statement_return(leaf, ctx):
+    lhs = expression(leaf.variable, ctx)
+    rhs = lhs + expression(leaf.expression, ctx)
+    return [lp.Assignment(lhs, rhs, within_inames=ctx.active_inames())]
+
+
+@statement.register(imp.ReturnAccumulate)
+def statement_returnaccumulate(leaf, ctx):
+    lhs = expression(leaf.variable, ctx)
+    rhs = lhs + expression(leaf.indexsum.children[0], ctx)
+    return [lp.Assignment(lhs, rhs, within_inames=ctx.active_inames())]
+
+
+@statement.register(imp.Evaluate)
+def statement_evaluate(leaf, ctx):
+    expr = leaf.expression
+    if isinstance(expr, gem.ListTensor):
+        ops = []
+        var = ctx.pymbolic_variable(expr)
+        index = ()
+        if isinstance(var, p.Subscript):
+            # TODO: Probably can do this better
+            var, index = var.aggregate, var.index_tuple
+        for multiindex, value in numpy.ndenumerate(expr.array):
+            ops.append(lp.Assignment(p.Subscript(var, index + multiindex), expression(value, ctx), within_inames=ctx.active_inames()))
+        return ops
+    elif isinstance(expr, gem.Constant):
+        return []
+    else:
+        return [lp.Assignment(ctx.pymbolic_variable(expr), expression(expr, ctx, top=True), within_inames=ctx.active_inames())]
+
+
+def expression(expr, ctx, top=False):
+    """Translates GEM expression into a pymbolic expression
+
+    :arg expr: GEM expression
+    :arg ctx: miscellaneous code generation data
+    :arg top: do not generate temporary reference for the root node
+    :returns: pymbolic expression
+    """
+    # TODO: fix top
+    if not top and expr in ctx.gem_to_pymbolic:
+        return ctx.pymbolic_variable(expr)
+    else:
+        return _expression(expr, ctx)
+
+
+@singledispatch
+def _expression(expr, parameters):
+    raise AssertionError("cannot generate expression from %s" % type(expr))
+
+
+@_expression.register(gem.Failure)
+def _expression_failure(expr, parameters):
+    raise expr.exception
+
+
+@_expression.register(gem.Product)
+def _expression_product(expr, ctx):
+    return p.Product(tuple([expression(c, ctx) for c in expr.children]))
+
+
+@_expression.register(gem.Sum)
+def _expression_sum(expr, ctx):
+    return p.Sum(tuple([expression(c, ctx) for c in expr.children]))
+
+
+@_expression.register(gem.Division)
+def _expression_division(expr, ctx):
+    return p.Quotient(*[expression(c, ctx) for c in expr.children])
+
+
+@_expression.register(gem.Power)
+def _expression_power(expr, ctx):
+    base, exponent = expr.children
+    return p.Power(expression(base, ctx), expression(exponent, ctx))
+
+
+@_expression.register(gem.MathFunction)
+def _expression_mathfunction(expr, ctx):
+    name_map = {
+        'abs': 'fabs',
+        'ln': 'log',
+
+        # Bessel functions
+        'cyl_bessel_j': 'jn',
+        'cyl_bessel_y': 'yn',
+
+        # Modified Bessel functions (C++ only)
+        #
+        # These mappings work for FEniCS only, and fail with Firedrake
+        # since no Boost available.
+        'cyl_bessel_i': 'boost::math::cyl_bessel_i',
+        'cyl_bessel_k': 'boost::math::cyl_bessel_k',
+    }
+    name = name_map.get(expr.name, expr.name)
+    if name == 'jn':
+        assert False
+        nu, arg = expr.children
+        if nu == gem.Zero():
+            return p.Variable("j0")(expression(arg, ctx))
+        elif nu == gem.one:
+            return p.Variable("j1")(expression(arg, ctx))
+    if name == 'yn':
+        assert False
+        nu, arg = expr.children
+        if nu == gem.Zero():
+            return p.Variable("y0")(expression(arg, ctx))
+        elif nu == gem.one:
+            return p.Variable("y1")(expression(arg, ctx))
+    return p.Variable(name)(*[expression(c, ctx) for c in expr.children])
+
+
+@_expression.register(gem.MinValue)
+def _expression_minvalue(expr, ctx):
+    # return p.Min(tuple(expression(c, ctx) for c in expr.children))
+    # loopy will translate p.Min to min() rather than fmin()
+    return p.Variable("min")(*[expression(c, ctx) for c in expr.children])
+
+
+@_expression.register(gem.MaxValue)
+def _expression_maxvalue(expr, ctx):
+    return p.Variable("max")(*[expression(c, ctx) for c in expr.children])
+
+
+@_expression.register(gem.Comparison)
+def _expression_comparison(expr, ctx):
+    left, right = [expression(c, ctx) for c in expr.children]
+    return p.Comparison(left, expr.operator, right)
+
+
+@_expression.register(gem.LogicalNot)
+def _expression_logicalnot(expr, ctx):
+    return p.LogicalNot(tuple([expression(c, ctx) for c in expr.children]))
+
+
+@_expression.register(gem.LogicalAnd)
+def _expression_logicaland(expr, ctx):
+    return p.LogicalAnd(tuple([expression(c, ctx) for c in expr.children]))
+
+
+@_expression.register(gem.LogicalOr)
+def _expression_logicalor(expr, ctx):
+    return p.LogicalOr(tuple([expression(c, ctx) for c in expr.children]))
+
+
+@_expression.register(gem.Conditional)
+def _expression_conditional(expr, ctx):
+    return p.If(*[expression(c, ctx) for c in expr.children])
+
+
+@_expression.register(gem.Constant)
+def _expression_scalar(expr, parameters):
+    assert not expr.shape
+    v = expr.value
+    if isnan(v):
+        return p.Variable("NAN")
+    r = round(v, 1)
+    if r and abs(v - r) < parameters.epsilon:
+        return r
+    return v
+
+
+@_expression.register(gem.Variable)
+def _expression_variable(expr, ctx):
+    return ctx.pymbolic_variable(expr)
+
+
+@_expression.register(gem.Indexed)
+def _expression_indexed(expr, ctx):
+    rank = ctx.pym_multiindex(expr.multiindex)
+    var = expression(expr.children[0], ctx)
+    if isinstance(var, p.Subscript):
+        rank = var.index + rank
+        var = var.aggregate
+    return p.Subscript(var, rank)
+
+
+@_expression.register(gem.FlexiblyIndexed)
+def _expression_flexiblyindexed(expr, ctx):
+    var = expression(expr.children[0], ctx)
+
+    rank = []
+    for off, idxs in expr.dim2idxs:
+        for index, stride in idxs:
+            assert isinstance(index, gem.Index)
+
+        rank_ = [off]
+        for index, stride in idxs:
+            rank_.append(p.Product((ctx.active_indices[index], stride)))
+        rank.append(p.Sum(tuple(rank_)))
+
+    return p.Subscript(var, tuple(rank))

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -2,8 +2,6 @@
 
 This is the final stage of code generation in TSFC."""
 
-from __future__ import absolute_import, print_function, division
-
 from math import isnan
 
 import numpy

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -81,7 +81,7 @@ def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=
     for i, temp in enumerate(impero_c.temporaries):
         name = "t%d" % i
         if isinstance(temp, gem.Constant):
-            data.append(lp.TemporaryVariable(name, shape=temp.shape, dtype=temp.array.dtype, initializer=temp.array, scope=lp.temp_var_scope.LOCAL, read_only=True))
+            data.append(lp.TemporaryVariable(name, shape=temp.shape, dtype=temp.array.dtype, initializer=temp.array, scope=lp.temp_var_scope.GLOBAL, read_only=True))
         else:
             shape = tuple([i.extent for i in ctx.indices[temp]]) + temp.shape
             data.append(lp.TemporaryVariable(name, shape=shape, dtype=numpy.float64, initializer=None, scope=lp.temp_var_scope.LOCAL, read_only=False))
@@ -99,9 +99,9 @@ def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=
         domains = [isl.BasicSet("[] -> {[]}")]
 
     knl = lp.make_kernel(domains, instructions, data, name=kernel_name, target=lp.CTarget(), seq_dependencies=True)
-    # print(knl)
-    # iname_tag = dict((i, 'ord') for i in knl.all_inames())
-    # knl = lp.tag_inames(knl, iname_tag)
+
+    # TODO: temporary fix to prevent loop transpose
+    knl = lp.prioritize_loops(knl, ",".join(ctx.index_extent.keys()))
     return knl
 
 

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -101,7 +101,7 @@ def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=
         domains = [isl.BasicSet("[] -> {[]}")]
 
     # Create loopy kernel
-    knl = lp.make_kernel(domains, instructions, data, name=kernel_name, target=lp.CTarget(), seq_dependencies=True)
+    knl = lp.make_kernel(domains, instructions, data, name=kernel_name, target=lp.CTarget(), seq_dependencies=True, lang_version=(2018, 1))
 
     # Prevent loopy interchange by loopy
     knl = lp.prioritize_loops(knl, ",".join(ctx.index_extent.keys()))

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -22,23 +22,23 @@ from pytools import UniqueNameGenerator
 
 class LoopyContext(object):
     def __init__(self):
-        self.indices = {}
+        self.indices = {}  # indices for declarations and referencing values, from ImperoC
         self.active_indices = {}  # gem index -> pymbolic variable
-        self.index_extent = OrderedDict()  # pymbolic variable for indices - > extent
+        self.index_extent = OrderedDict()  # pymbolic variable for indices -> extent
         self.gem_to_pymbolic = {}  # gem node -> pymbolic variable
         self.name_gen = UniqueNameGenerator()
 
     def pym_multiindex(self, multiindex):
-        rank = []
+        indices = []
         for index in multiindex:
             if isinstance(index, gem.Index):
-                rank.append(self.active_indices[index])
+                indices.append(self.active_indices[index])
             elif isinstance(index, gem.VariableIndex):
-                rank.append(expression(index.expression, self))
+                indices.append(expression(index.expression, self))
             else:
                 assert isinstance(index, int)
-                rank.append(index)
-        return tuple(rank)
+                indices.append(index)
+        return tuple(indices)
 
     def pymbolic_variable(self, node):
         try:
@@ -48,11 +48,9 @@ class LoopyContext(object):
             pym = p.Variable(name)
             self.gem_to_pymbolic[node] = pym
         if node in self.indices:
-            rank = self.pym_multiindex(self.indices[node])
-            if rank:
-                return p.Subscript(pym, rank)
-            else:
-                return pym
+            indices = self.pym_multiindex(self.indices[node])
+            if indices:
+                return p.Subscript(pym, indices)
         else:
             return pym
 

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -104,7 +104,7 @@ def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=
 
     # Create loopy kernel
     knl = lp.make_function(domains, instructions, data, name=kernel_name, target=lp.CTarget(),
-                           seq_dependencies=True,  silenced_warnings=["summing_if_branches_ops"])
+                           seq_dependencies=True, silenced_warnings=["summing_if_branches_ops"])
 
     # Prevent loopy interchange by loopy
     knl = lp.prioritize_loops(knl, ",".join(ctx.index_extent.keys()))

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -238,7 +238,7 @@ def _expression_division(expr, ctx):
 
 @_expression.register(gem.Power)
 def _expression_power(expr, ctx):
-    return p.Power(*(expression(c, ctx) for c in expr.children))
+    return p.Variable("pow")(*(expression(c, ctx) for c in expr.children))
 
 
 @_expression.register(gem.MathFunction)

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -99,7 +99,9 @@ def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=
         domains = [isl.BasicSet("[] -> {[]}")]
 
     # Create loopy kernel
-    knl = lp.make_kernel(domains, instructions, data, name=kernel_name, target=lp.CTarget(), seq_dependencies=True, lang_version=(2018, 1))
+    knl = lp.make_kernel(domains, instructions, data, name=kernel_name, target=lp.CTarget(),
+                         seq_dependencies=True, lang_version=(2018, 2),
+                         silenced_warnings=["summing_if_branches_ops"])
 
     # Prevent loopy interchange by loopy
     knl = lp.prioritize_loops(knl, ",".join(ctx.index_extent.keys()))

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -17,6 +17,8 @@ import pymbolic.primitives as p
 
 from pytools import UniqueNameGenerator
 
+from tsfc.parameters import SCALAR_TYPE
+
 
 class LoopyContext(object):
     def __init__(self):
@@ -59,12 +61,13 @@ class LoopyContext(object):
         return frozenset([i.name for i in self.active_indices.values()])
 
 
-def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=[]):
+def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=[], scalar_type=None):
     """Generates loopy code.
 
     :arg impero_c: ImperoC tuple with Impero AST and other data
     :arg args: list of loopy.GlobalArgs
     :arg precision: floating-point precision for printing
+    :arg scalar_type: type of scalars as C typename string
     :arg kernel_name: function name of the kernel
     :arg index_names: pre-assigned index names
     :returns: loopy kernel
@@ -73,6 +76,7 @@ def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=
     ctx.indices = impero_c.indices
     ctx.index_names = defaultdict(lambda: "i", index_names)
     ctx.precision = precision
+    ctx.scalar_type = scalar_type or SCALAR_TYPE
     ctx.epsilon = 10.0 ** (-precision)
 
     # Create arguments

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -80,10 +80,10 @@ def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=
     for i, temp in enumerate(impero_c.temporaries):
         name = "t%d" % i
         if isinstance(temp, gem.Constant):
-            data.append(lp.TemporaryVariable(name, shape=temp.shape, dtype=temp.array.dtype, initializer=temp.array, scope=lp.AddressSpace.GLOBAL, read_only=True))
+            data.append(lp.TemporaryVariable(name, shape=temp.shape, dtype=temp.array.dtype, initializer=temp.array, address_space=lp.AddressSpace.GLOBAL, read_only=True))
         else:
             shape = tuple([i.extent for i in ctx.indices[temp]]) + temp.shape
-            data.append(lp.TemporaryVariable(name, shape=shape, dtype=numpy.float64, initializer=None, scope=lp.AddressSpace.LOCAL, read_only=False))
+            data.append(lp.TemporaryVariable(name, shape=shape, dtype=numpy.float64, initializer=None, address_space=lp.AddressSpace.LOCAL, read_only=False))
         ctx.gem_to_pymbolic[temp] = p.Variable(name)
 
     # Create instructions

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -127,10 +127,8 @@ def statement(tree, ctx):
 
 @statement.register(imp.Block)
 def statement_block(tree, ctx):
-    statements = []
-    for child in tree.children:
-        statements.extend(statement(child, ctx))
-    return statements
+    from itertools import chain
+    return list(chain(*(statement(child, ctx) for child in tree.children)))
 
 
 @statement.register(imp.For)
@@ -217,29 +215,28 @@ def _expression_failure(expr, parameters):
 
 @_expression.register(gem.Product)
 def _expression_product(expr, ctx):
-    return p.Product(tuple([expression(c, ctx) for c in expr.children]))
+    return p.Product(tuple(expression(c, ctx) for c in expr.children))
 
 
 @_expression.register(gem.Sum)
 def _expression_sum(expr, ctx):
-    return p.Sum(tuple([expression(c, ctx) for c in expr.children]))
+    return p.Sum(tuple(expression(c, ctx) for c in expr.children))
 
 
 @_expression.register(gem.Division)
 def _expression_division(expr, ctx):
-    return p.Quotient(*[expression(c, ctx) for c in expr.children])
+    return p.Quotient(*(expression(c, ctx) for c in expr.children))
 
 
 @_expression.register(gem.Power)
 def _expression_power(expr, ctx):
-    base, exponent = expr.children
-    return p.Power(expression(base, ctx), expression(exponent, ctx))
+    return p.Power(*(expression(c, ctx) for c in expr.children))
 
 
 @_expression.register(gem.MathFunction)
 def _expression_mathfunction(expr, ctx):
     name_map = {
-        'abs': 'fabs',
+        'abs': 'abs',
         'ln': 'log'
     }
     name = name_map.get(expr.name, expr.name)

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -241,36 +241,14 @@ def _expression_power(expr, ctx):
     return p.Power(*(expression(c, ctx) for c in expr.children))
 
 
-# Table of handled math functions in real and complex modes
-# Copied from FFCX (ffc/language/ufl_to_cnodes.py), except changing fabs to abs for real absolute value
-math_table = {
-    'sqrt': ('sqrt', 'csqrt'),
-    'abs': ('abs', 'cabs'),
-    'cos': ('cos', 'ccos'),
-    'sin': ('sin', 'csin'),
-    'tan': ('tan', 'ctan'),
-    'acos': ('acos', 'cacos'),
-    'asin': ('asin', 'casin'),
-    'atan': ('atan', 'catan'),
-    'cosh': ('cosh', 'ccosh'),
-    'sinh': ('sinh', 'csinh'),
-    'tanh': ('tanh', 'ctanh'),
-    'acosh': ('acosh', 'cacosh'),
-    'asinh': ('asinh', 'casinh'),
-    'atanh': ('atanh', 'catanh'),
-    'exp': ('exp', 'cexp'),
-    'ln': ('log', 'clog'),
-    'real': (None, 'creal'),
-    'imag': (None, 'cimag'),
-    'conj': (None, 'conj'),
-    'erf': ('erf', None),
-    'atan_2': ('atan2', None),
-    'atan2': ('atan2', None),
-}
-
-
 @_expression.register(gem.MathFunction)
 def _expression_mathfunction(expr, ctx):
+
+    from tsfc.coffee import math_table
+
+    math_table = math_table.copy()
+    math_table['abs'] = ('abs', 'cabs')
+
     complex_mode = int(is_complex(ctx.scalar_type))
 
     # Bessel functions
@@ -311,7 +289,7 @@ def _expression_mathfunction(expr, ctx):
     if name is None:
         raise RuntimeError("{} not supported in complex mode".format(expr.name))
 
-    return p.Variable(expr.name)(*[expression(c, ctx) for c in expr.children])
+    return p.Variable(name)(*[expression(c, ctx) for c in expr.children])
 
 
 @_expression.register(gem.MinValue)

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -51,6 +51,8 @@ class LoopyContext(object):
             indices = self.pym_multiindex(self.indices[node])
             if indices:
                 return p.Subscript(pym, indices)
+            else:
+                return pym
         else:
             return pym
 


### PR DESCRIPTION
This PR adds the capability to generate loopy kernels instead of coffee kernels.

I duplicated a lot of code in `kernel_interface/firedrake_loopy.py` because I think it will replace `kernel_interface/firedrake.py` eventually, when loopy supports all operations we need in firedrake, so probably not worthwhile to build a common parent class for the two interfaces.

The default behaviour of calling `compile_form()` is still generating a coffee kernel, so it shouldn't affect customers who uses tsfc other than firedrake.