### PR TITLE
Allow KernelBuilder to control unsummed coefficient free indices

### DIFF
--- a/tsfc/kernel_interface/__init__.py
+++ b/tsfc/kernel_interface/__init__.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, abstractproperty
 
 from gem.utils import make_proxy_class
 
@@ -29,6 +29,11 @@ class KernelInterface(metaclass=ABCMeta):
     def create_element(self, element, **kwargs):
         """Create a FInAT element (suitable for tabulating with) given
         a UFL element."""
+
+    @abstractproperty
+    def unsummed_coefficient_indices(self):
+        """A set of indices that coefficient evaluation should not sum over.
+        Used for macro-cell integration."""
 
 
 ProxyKernelInterface = make_proxy_class('ProxyKernelInterface', KernelInterface)

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -4,6 +4,8 @@ import coffee.base as coffee
 
 import gem
 
+from gem.utils import cached_property
+
 from tsfc.kernel_interface import KernelInterface
 
 
@@ -26,6 +28,10 @@ class KernelBuilderBase(KernelInterface):
 
         # Coefficients
         self.coefficient_map = {}
+
+    @cached_property
+    def unsummed_coefficient_indices(self):
+        return frozenset()
 
     def coordinate(self, domain):
         return self.domain_coordinate[domain]


### PR DESCRIPTION
For performing macro-cell integration, when evaluating a coefficient,
we do not necessarily immediately want to sum over all of its free
indices.  Allow the KernelBuilder to specify a set of indices that
should be removed from a coefficient's index_ordering before summing
over them.