### PR TITLE
Runtime tabulated

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -198,6 +198,8 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     expressions = impero_utils.preprocess_gem(expressions, **options)
     assignments = list(zip(return_variables, expressions))
 
+    builder.register_tabulations(expressions)
+
     # Look for cell orientations in the IR
     if builder.needs_cell_orientations(expressions):
         builder.require_cell_orientations()
@@ -236,7 +238,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     # Construct kernel
     body = generate_coffee(impero_c, index_names, parameters["precision"], expressions, split_argument_indices)
 
-    return builder.construct_kernel(kernel_name, body)
+    return builder.construct_kernel(kernel_name, body, quad_rule)
 
 
 def compile_expression_at_points(expression, points, coordinates, parameters=None):

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -461,7 +461,7 @@ def fiat_to_ufl(fiat_dict, order):
 def translate_argument(terminal, mt, ctx):
     argument_multiindex = ctx.argument_multiindices[terminal.number()]
     sigma = tuple(gem.Index(extent=d) for d in mt.expr.ufl_shape)
-    element = ctx.create_element(terminal.ufl_element())
+    element = ctx.create_element(terminal.ufl_element(), restriction=mt.restriction)
 
     def callback(entity_id):
         finat_dict = ctx.basis_evaluation(element, mt.local_derivatives, entity_id)
@@ -488,7 +488,7 @@ def translate_coefficient(terminal, mt, ctx):
         assert mt.local_derivatives == 0
         return vec
 
-    element = ctx.create_element(terminal.ufl_element())
+    element = ctx.create_element(terminal.ufl_element(), restriction=mt.restriction)
 
     # Collect FInAT tabulation for all entities
     per_derivative = collections.defaultdict(list)

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -122,6 +122,12 @@ def convert_finiteelement(element, **kwargs):
             lmbda = finat.Lagrange
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLobattoLegendre
+        elif kind in ['mgd', 'feec','qb','mse']:
+            degree = element.degree()
+            shift_axes = kwargs["shift_axes"]
+            restriction = kwargs["restriction"]
+            deps = {"shift_axes", "restriction"}
+            return finat.RuntimeTabulated(cell, degree, kind, shift_axes, restriction), deps
         else:
             raise ValueError("Variant %r not supported on %s" % (kind, element.cell()))
     elif element.family() == "Discontinuous Lagrange":
@@ -130,6 +136,12 @@ def convert_finiteelement(element, **kwargs):
             lmbda = finat.DiscontinuousLagrange
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLegendre
+        elif kind in ['mgd', 'feec','qb','mse']:
+            degree = element.degree()
+            shift_axes = kwargs["shift_axes"]
+            restriction = kwargs["restriction"]
+            deps = {"shift_axes", "restriction"}
+            return finat.RuntimeTabulated(cell, degree, kind, shift_axes, restriction, continuous=False), deps
         else:
             raise ValueError("Variant %r not supported on %s" % (kind, element.cell()))
     return lmbda(cell, element.degree()), set()
@@ -179,9 +191,19 @@ def convert_tensorproductelement(element, **kwargs):
     cell = element.cell()
     if type(cell) is not ufl.TensorProductCell:
         raise ValueError("TensorProductElement not on TensorProductCell?")
-    elements, deps = zip(*[_create_element(elem, **kwargs)
-                           for elem in element.sub_elements()])
-    return finat.TensorProductElement(elements), set.union(*deps)
+    shift_axes = kwargs["shift_axes"]
+    dim_offset = 0
+
+    elements = []
+    deps = set()
+    for elem in element.sub_elements():
+        kwargs["shift_axes"] = shift_axes + dim_offset
+        dim_offset += elem.cell().topological_dimension()
+
+        finat_elem, ds = _create_element(elem, **kwargs)
+        elements.append(finat_elem)
+        deps.update(ds)
+    return finat.TensorProductElement(elements), deps
 
 
 @convert.register(ufl.HDivElement)
@@ -212,14 +234,20 @@ quadrilateral_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval)
 _cache = weakref.WeakKeyDictionary()
 
 
-def create_element(ufl_element, shape_innermost=True):
+def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None):
     """Create a FInAT element (suitable for tabulating with) given a UFL element.
 
     :arg ufl_element: The UFL element to create a FInAT element from.
     :arg shape_innermost: Vector/tensor indices come after basis function indices
+    :arg shift_axes: shift axes for runtime tabulated elements inside
+                     tensor product elements
+    :arg restriction: cell restriction in interior facet integrals
+                      (only for runtime tabulated elements)
     """
     finat_element, deps = _create_element(ufl_element,
-                                          shape_innermost=shape_innermost)
+                                          shape_innermost=shape_innermost,
+                                          shift_axes=shift_axes,
+                                          restriction=restriction)
     return finat_element
 
 

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -122,7 +122,7 @@ def convert_finiteelement(element, **kwargs):
             lmbda = finat.Lagrange
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLobattoLegendre
-        elif kind in ['mgd', 'feec','qb','mse']:
+        elif kind in ['mgd', 'feec', 'qb', 'mse']:
             degree = element.degree()
             shift_axes = kwargs["shift_axes"]
             restriction = kwargs["restriction"]
@@ -136,7 +136,7 @@ def convert_finiteelement(element, **kwargs):
             lmbda = finat.DiscontinuousLagrange
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLegendre
-        elif kind in ['mgd', 'feec','qb','mse']:
+        elif kind in ['mgd', 'feec', 'qb', 'mse']:
             degree = element.degree()
             shift_axes = kwargs["shift_axes"]
             restriction = kwargs["restriction"]

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -253,7 +253,7 @@ class KernelBuilder(KernelBuilderBase):
             args.append(coffee.Decl("unsigned int",
                                     coffee.Symbol("facet", rank=(2,)),
                                     qualifiers=["const"]))
-                                    
+
         for name_, shape in self.tabulations:
             args.append(coffee.Decl(SCALAR_TYPE, coffee.Symbol(
                 name_, rank=shape), qualifiers=["const"]))
@@ -288,8 +288,8 @@ def prepare_coefficient(coefficient, name, interior_facet=False):
 
     if coefficient.ufl_element().family() == 'Real':
         # Constant
-        funarg = coffee.Decl(SCALAR_TYPE,  coffee.Symbol(name, rank=(1,)),
-                             #pointers=[("restrict",)],
+        funarg = coffee.Decl(SCALAR_TYPE, coffee.Symbol(name, rank=(1,)),
+                             # pointers=[("restrict",)],
                              qualifiers=["const"])
 
         expression = gem.reshape(gem.Variable(name, (None,)),
@@ -301,8 +301,8 @@ def prepare_coefficient(coefficient, name, interior_facet=False):
     shape = finat_element.index_shape
     size = numpy.prod(shape, dtype=int)
 
-	#THIS IS MISSING THE OLD TENSOR_SHAPE ARGUMENT FOR THE RANK
-	#IS THIS OK? ONLY MATTERS FOR TENSOR FINITE ELEMENTS I THINK?
+# THIS IS MISSING THE OLD TENSOR_SHAPE ARGUMENT FOR THE RANK
+# IS THIS OK? ONLY MATTERS FOR TENSOR FINITE ELEMENTS I THINK?
     if not interior_facet:
         funarg = coffee.Decl(SCALAR_TYPE, coffee.Symbol(name, rank=(size,)), qualifiers=["const"])
     else:


### PR DESCRIPTION
This adds support for runtime tabulated elements (used in Themis) to TSFC. The only place I can foresee issues is kernel_interface/firedrake.py, since this changes some of the kernel arguments from pointers to const arrays (but it seems to pass tests on Travis?).  Should I create a new kernel_interface?
