### PR TITLE
Add support for new FInAT PhysicalGeometry callbacks

### DIFF
--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -172,7 +172,8 @@ def _select_expression(expressions, index):
     types = set(map(type, expressions))
     if types <= {Indexed, Zero}:
         multiindex, = set(e.multiindex for e in expressions if isinstance(e, Indexed))
-        shape = tuple(i.extent for i in multiindex)
+        # Shape only determined by free indices
+        shape = tuple(i.extent for i in multiindex if isinstance(i, Index))
 
         def child(expression):
             if isinstance(expression, Indexed):

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -7,7 +7,7 @@ from itertools import chain
 
 from numpy import asarray
 
-import ufl
+# import ufl
 from ufl.algorithms import extract_arguments, extract_coefficients
 from ufl.algorithms.analysis import has_type
 from ufl.classes import Form, GeometricQuantity

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -141,7 +141,8 @@ def compile_integral(integral_data, form_data, prefix, parameters,
         mode = pick_mode(params["mode"])
         mode_irs.setdefault(mode, collections.OrderedDict())
 
-        integrand = ufl.replace(integral.integrand(), form_data.function_replace_map)
+        # integrand = ufl.replace(integral.integrand(), form_data.function_replace_map)
+        integrand = integral.integrand()
         integrand = ufl_utils.split_coefficients(integrand, builder.coefficient_split)
 
         # Check if the integral has a quad degree attached, otherwise use

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -105,6 +105,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     return_variables = builder.set_arguments(arguments, argument_multiindices)
 
     builder.set_coordinates(mesh)
+    builder.set_cell_sizes(mesh)
 
     builder.set_coefficients(integral_data, form_data)
 
@@ -202,6 +203,9 @@ def compile_integral(integral_data, form_data, prefix, parameters,
     # Look for cell orientations in the IR
     if builder.needs_cell_orientations(expressions):
         builder.require_cell_orientations()
+
+    if builder.needs_cell_sizes(expressions):
+        builder.require_cell_sizes()
 
     # Construct ImperoC
     split_argument_indices = tuple(chain(*[var.index_ordering()

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -7,7 +7,7 @@ from itertools import chain
 
 from numpy import asarray
 
-# import ufl
+import ufl
 from ufl.algorithms import extract_arguments, extract_coefficients
 from ufl.algorithms.analysis import has_type
 from ufl.classes import Form, GeometricQuantity
@@ -138,8 +138,7 @@ def compile_integral(integral_data, form_data, prefix, parameters,
         mode = pick_mode(params["mode"])
         mode_irs.setdefault(mode, collections.OrderedDict())
 
-        # integrand = ufl.replace(integral.integrand(), form_data.function_replace_map)
-        integrand = integral.integrand()
+        integrand = ufl.replace(integral.integrand(), form_data.function_replace_map)
         integrand = ufl_utils.split_coefficients(integrand, builder.coefficient_split)
 
         # Check if the integral has a quad degree attached, otherwise use

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -569,7 +569,6 @@ def translate_argument(terminal, mt, ctx):
 
 @translate.register(Coefficient)
 def translate_coefficient(terminal, mt, ctx):
-    # import ipdb; ipdb.set_trace()
     vec = ctx.coefficient(terminal, mt.restriction)
 
     if terminal.ufl_element().family() == 'Real':

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -484,14 +484,9 @@ def translate_coefficient(terminal, mt, ctx):
     # Collect FInAT tabulation for all entities
     per_derivative = collections.defaultdict(list)
     for entity_id in ctx.entity_ids:
-# <<<<<<< HEAD
-#         with MT.let(mt):
-#             finat_dict = ctx.basis_evaluation(element, mt.local_derivatives, entity_id)
-#         for alpha, table in iteritems(finat_dict):
-# =======
-        finat_dict = ctx.basis_evaluation(element, mt.local_derivatives, entity_id)
-        for alpha, table in finat_dict.items():
-# >>>>>>> origin/master
+         with MT.let(mt):
+             finat_dict = ctx.basis_evaluation(element, mt.local_derivatives, entity_id)
+         for alpha, table in finat_dict.items():
             # Filter out irrelevant derivatives
             if sum(alpha) == mt.local_derivatives:
                 # A numerical hack that FFC used to apply on FIAT

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -134,6 +134,9 @@ class CoordinateMapping(PhysicalGeometry):
         config["interface"] = self.interface
         return config
 
+    def cell_size(self):
+        return self.interface.cell_size(self.mt.restriction)
+
     def jacobian_at(self, point):
         expr = Jacobian(self.mt.terminal.ufl_domain())
         if self.mt.restriction == '+':

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -188,14 +188,15 @@ class PointSetContext(ContextBase):
                         gem.Product(gem.Indexed(jac, (0, 0)),
                                     gem.Literal(rts[i][0])),
                         gem.Product(gem.Indexed(jac, (0, 1)),
-                                    gem.Literal(rts[i][1]))
-                        ), gem.Indexed(els, (i,))),
-                      gem.Division(gem.Sum(
-                        gem.Product(gem.Indexed(jac, (1, 0)),
-                                    gem.Literal(rts[i][0])),
-                        gem.Product(gem.Indexed(jac, (1, 1)),
-                                    gem.Literal(rts[i][1]))
-                        ), gem.Indexed(els, (i,)))]
+                                    gem.Literal(rts[i][1]))),
+                                   gem.Indexed(els, (i,))),
+                      gem.Division(
+                          gem.Sum(
+                              gem.Product(gem.Indexed(jac, (1, 0)),
+                                          gem.Literal(rts[i][0])),
+                              gem.Product(gem.Indexed(jac, (1, 1)),
+                                          gem.Literal(rts[i][1]))
+                          ), gem.Indexed(els, (i,)))]
                      for i in range(3)])
 
             def physical_normals(cm):
@@ -204,9 +205,7 @@ class PointSetContext(ContextBase):
                     [[gem.Indexed(pts, (i, 1)),
                       gem.Product(gem.Literal(-1),
                                   gem.Indexed(pts, (i, 0)))]
-                     for i in range(3)]
-                    )
-
+                     for i in range(3)])
 
             def physical_edge_lengths(cm):
                 expr = ufl.classes.CellEdgeVectors(MT.value.terminal.ufl_domain())

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -30,6 +30,7 @@ from gem.optimise import ffc_rounding
 from gem.unconcatenate import unconcatenate
 from gem.utils import DynamicallyScoped, cached_property
 
+from finat.physical_geometry import PhysicalGeometry
 from finat.point_set import PointSet, PointSingleton
 from finat.quadrature import make_quadrature
 
@@ -146,7 +147,6 @@ class PointSetContext(ContextBase):
         return self.quadrature_rule.weight_expression
 
     def basis_evaluation(self, finat_element, local_derivatives, entity_id):
-        from finat.hermite import PhysicalGeometry
 
         class CoordinateMapping(PhysicalGeometry):
             def jacobian_at(cm, point):
@@ -484,9 +484,9 @@ def translate_coefficient(terminal, mt, ctx):
     # Collect FInAT tabulation for all entities
     per_derivative = collections.defaultdict(list)
     for entity_id in ctx.entity_ids:
-         with MT.let(mt):
-             finat_dict = ctx.basis_evaluation(element, mt.local_derivatives, entity_id)
-         for alpha, table in finat_dict.items():
+        with MT.let(mt):
+            finat_dict = ctx.basis_evaluation(element, mt.local_derivatives, entity_id)
+        for alpha, table in finat_dict.items():
             # Filter out irrelevant derivatives
             if sum(alpha) == mt.local_derivatives:
                 # A numerical hack that FFC used to apply on FIAT

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -46,6 +46,12 @@ def morley_element(cell, degree):
     return Morley(cell)
 
 
+def argyris_element(cell, degree):
+    assert degree in {5, None}
+    from finat.argyris import Argyris
+    return Argyris(cell)
+
+
 supported_elements = {
     # These all map directly to FInAT elements
     "Brezzi-Douglas-Marini": finat.BrezziDouglasMarini,
@@ -62,6 +68,7 @@ supported_elements = {
     "Hellan-Herrmann-Johnson": finat.HellanHerrmannJohnson,
     "Hermite": hermite_element,
     "Morley": morley_element,
+    "Argyris": argyris_element,
     "Lagrange": finat.Lagrange,
     "Nedelec 1st kind H(curl)": finat.Nedelec,
     "Nedelec 2nd kind H(curl)": finat.NedelecSecondKind,

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -52,6 +52,12 @@ def argyris_element(cell, degree):
     return Argyris(cell)
 
 
+def bell_element(cell, degree):
+    assert degree in {5, None}
+    from finat.bell import Bell
+    return Bell(cell)
+
+
 supported_elements = {
     # These all map directly to FInAT elements
     "Brezzi-Douglas-Marini": finat.BrezziDouglasMarini,
@@ -67,8 +73,9 @@ supported_elements = {
     "HDiv Trace": finat.HDivTrace,
     "Hellan-Herrmann-Johnson": finat.HellanHerrmannJohnson,
     "Hermite": hermite_element,
-    "Morley": morley_element,
     "Argyris": argyris_element,
+    "Morley": morley_element,
+    "Bell": bell_element,
     "Lagrange": finat.Lagrange,
     "Nedelec 1st kind H(curl)": finat.Nedelec,
     "Nedelec 2nd kind H(curl)": finat.NedelecSecondKind,

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -40,6 +40,12 @@ def hermite_element(cell, degree):
     return CubicHermite(cell)
 
 
+def morley_element(cell, degree):
+    assert degree in {2, None}
+    from finat.morley import Morley
+    return Morley(cell)
+
+
 supported_elements = {
     # These all map directly to FInAT elements
     "Brezzi-Douglas-Marini": finat.BrezziDouglasMarini,
@@ -55,6 +61,7 @@ supported_elements = {
     "HDiv Trace": finat.HDivTrace,
     "Hellan-Herrmann-Johnson": finat.HellanHerrmannJohnson,
     "Hermite": hermite_element,
+    "Morley": morley_element,
     "Lagrange": finat.Lagrange,
     "Nedelec 1st kind H(curl)": finat.Nedelec,
     "Nedelec 2nd kind H(curl)": finat.NedelecSecondKind,

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -37,6 +37,12 @@ from tsfc.fiatinterface import as_fiat_cell
 __all__ = ("create_element", "supported_elements", "as_fiat_cell")
 
 
+def hermite_element(cell, degree):
+    assert degree == 3
+    from finat.hermite import CubicHermite
+    return CubicHermite(cell)
+
+
 supported_elements = {
     # These all map directly to FInAT elements
     "Brezzi-Douglas-Marini": finat.BrezziDouglasMarini,
@@ -50,6 +56,7 @@ supported_elements = {
     "Gauss-Lobatto-Legendre": finat.GaussLobattoLegendre,
     "HDiv Trace": finat.HDivTrace,
     "Hellan-Herrmann-Johnson": finat.HellanHerrmannJohnson,
+    "Hermite": hermite_element,
     "Lagrange": finat.Lagrange,
     "Nedelec 1st kind H(curl)": finat.Nedelec,
     "Nedelec 2nd kind H(curl)": finat.NedelecSecondKind,

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -34,30 +34,6 @@ from tsfc.fiatinterface import as_fiat_cell
 __all__ = ("create_element", "supported_elements", "as_fiat_cell")
 
 
-def hermite_element(cell, degree):
-    assert degree == 3
-    from finat.hermite import CubicHermite
-    return CubicHermite(cell)
-
-
-def morley_element(cell, degree):
-    assert degree in {2, None}
-    from finat.morley import Morley
-    return Morley(cell)
-
-
-def argyris_element(cell, degree):
-    assert degree in {5, None}
-    from finat.argyris import Argyris
-    return Argyris(cell)
-
-
-def bell_element(cell, degree):
-    assert degree in {5, None}
-    from finat.bell import Bell
-    return Bell(cell)
-
-
 supported_elements = {
     # These all map directly to FInAT elements
     "Brezzi-Douglas-Marini": finat.BrezziDouglasMarini,
@@ -72,10 +48,10 @@ supported_elements = {
     "Gauss-Lobatto-Legendre": finat.GaussLobattoLegendre,
     "HDiv Trace": finat.HDivTrace,
     "Hellan-Herrmann-Johnson": finat.HellanHerrmannJohnson,
-    "Hermite": hermite_element,
-    "Argyris": argyris_element,
-    "Morley": morley_element,
-    "Bell": bell_element,
+    "Hermite": finat.Hermite,
+    "Argyris": finat.Argyris,
+    "Morley": finat.Morley,
+    "Bell": finat.Bell,
     "Lagrange": finat.Lagrange,
     "Nedelec 1st kind H(curl)": finat.Nedelec,
     "Nedelec 2nd kind H(curl)": finat.NedelecSecondKind,

--- a/tsfc/kernel_interface/__init__.py
+++ b/tsfc/kernel_interface/__init__.py
@@ -22,6 +22,10 @@ class KernelInterface(metaclass=ABCMeta):
         """Cell orientation as a GEM expression."""
 
     @abstractmethod
+    def cell_size(self, restriction):
+        """Mesh cell size as a GEM expression.  Shape (nvertex, ) in FIAT vertex ordering."""
+
+    @abstractmethod
     def entity_number(self, restriction):
         """Facet or vertex number as a GEM index."""
 

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -58,6 +58,11 @@ class KernelBuilderBase(KernelInterface):
                                                gem.Literal(1),
                                                gem.Literal(numpy.nan)))
 
+    def cell_size(self, restriction):
+        f = {None: (), '+': (0, ), '-': (1, )}[restriction]
+        # cell_sizes expression must have been set up by now.
+        return gem.partial_indexed(self._cell_sizes, f)
+
     def entity_number(self, restriction):
         """Facet or vertex number as a GEM index."""
         # Assume self._entity_number dict is set up at this point.

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -247,6 +247,15 @@ class KernelBuilder(KernelBuilderBase):
         self.kernel.needs_cell_sizes = True
 
     def set_cell_sizes(self, domain):
+        """Setup a fake coefficient for "cell sizes".
+
+        :arg domain: The domain of the integral.
+
+        This is required for scaling of derivative basis functions on
+        physically mapped elements (Argyris, Bell, etc...).  We need a
+        measure of the mesh size around each vertex (hence this lives
+        in P1).
+        """
         f = Coefficient(FunctionSpace(domain, FiniteElement("P", domain.ufl_cell(), 1)))
         funarg, expression = prepare_coefficient(f, "cell_sizes", interior_facet=self.interior_facet)
         self.cell_sizes_arg = funarg

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -219,7 +219,7 @@ class KernelBuilder(KernelBuilderBase):
         # of reduced_coefficients the integral requires.
         for i in range(len(integral_data.enabled_coefficients)):
             if integral_data.enabled_coefficients[i]:
-                coefficient = form_data.reduced_coefficients[i]
+                coefficient = form_data.function_replace_map[form_data.reduced_coefficients[i]]
                 if type(coefficient.ufl_element()) == ufl_MixedElement:
                     split = [Coefficient(FunctionSpace(coefficient.ufl_domain(), element))
                              for element in coefficient.ufl_element().sub_elements()]

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -2,7 +2,7 @@ import numpy
 from collections import namedtuple
 from itertools import chain, product
 
-from ufl import Coefficient, MixedElement as ufl_MixedElement, FunctionSpace
+from ufl import Coefficient, MixedElement as ufl_MixedElement, FunctionSpace, FiniteElement
 
 import coffee.base as coffee
 
@@ -21,7 +21,7 @@ ExpressionKernel = namedtuple('ExpressionKernel', ['ast', 'oriented', 'coefficie
 
 class Kernel(object):
     __slots__ = ("ast", "integral_type", "oriented", "subdomain_id",
-                 "domain_number",
+                 "domain_number", "needs_cell_sizes",
                  "coefficient_numbers", "__weakref__")
     """A compiled Kernel object.
 
@@ -34,10 +34,12 @@ class Kernel(object):
         original_form.ufl_domains() to get the correct domain).
     :kwarg coefficient_numbers: A list of which coefficients from the
         form the kernel needs.
+    :kwarg needs_cell_sizes: Does the kernel require cell sizes.
     """
     def __init__(self, ast=None, integral_type=None, oriented=False,
                  subdomain_id=None, domain_number=None,
-                 coefficient_numbers=()):
+                 coefficient_numbers=(),
+                 needs_cell_sizes=False):
         # Defaults
         self.ast = ast
         self.integral_type = integral_type
@@ -45,6 +47,7 @@ class Kernel(object):
         self.domain_number = domain_number
         self.subdomain_id = subdomain_id
         self.coefficient_numbers = coefficient_numbers
+        self.needs_cell_sizes = needs_cell_sizes
         super(Kernel, self).__init__()
 
 
@@ -87,6 +90,15 @@ class KernelBuilderBase(_KernelBuilderBase):
                 return True
         return False
 
+    @staticmethod
+    def needs_cell_sizes(ir):
+        """Does a multi-root GEM expression DAG references cell
+        orientations?"""
+        for node in traversal(ir):
+            if isinstance(node, gem.Variable) and node.name == "cell_sizes":
+                return True
+        return False
+
     def create_element(self, element, **kwargs):
         """Create a FInAT element (suitable for tabulating with) given
         a UFL element."""
@@ -123,6 +135,15 @@ class ExpressionKernelBuilder(KernelBuilderBase):
     def require_cell_orientations(self):
         """Set that the kernel requires cell orientations."""
         self.oriented = True
+
+    @staticmethod
+    def needs_cell_sizes(ir):
+        # Not hooked up
+        return False
+
+    @staticmethod
+    def require_cell_sizes():
+        pass
 
     def construct_kernel(self, return_arg, body):
         """Constructs an :class:`ExpressionKernel`.
@@ -221,6 +242,16 @@ class KernelBuilder(KernelBuilderBase):
         """Set that the kernel requires cell orientations."""
         self.kernel.oriented = True
 
+    def require_cell_sizes(self):
+        """Set that the kernel requires cell sizes."""
+        self.kernel.needs_cell_sizes = True
+
+    def set_cell_sizes(self, domain):
+        f = Coefficient(FunctionSpace(domain, FiniteElement("P", domain.ufl_cell(), 1)))
+        funarg, expression = prepare_coefficient(f, "cell_sizes", interior_facet=self.interior_facet)
+        self.cell_sizes_arg = funarg
+        self._cell_sizes = expression
+
     def construct_kernel(self, name, body):
         """Construct a fully built :class:`Kernel`.
 
@@ -234,6 +265,8 @@ class KernelBuilder(KernelBuilderBase):
         args = [self.local_tensor, self.coordinates_arg]
         if self.kernel.oriented:
             args.append(cell_orientations_coffee_arg)
+        if self.kernel.needs_cell_sizes:
+            args.append(self.cell_sizes_arg)
         args.extend(self.coefficient_args)
         if self.kernel.integral_type in ["exterior_facet", "exterior_facet_vert"]:
             args.append(coffee.Decl("unsigned int",

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -92,8 +92,7 @@ class KernelBuilderBase(_KernelBuilderBase):
 
     @staticmethod
     def needs_cell_sizes(ir):
-        """Does a multi-root GEM expression DAG references cell
-        orientations?"""
+        """Does a multi-root GEM expression DAG reference cell sizes?"""
         for node in traversal(ir):
             if isinstance(node, gem.Variable) and node.name == "cell_sizes":
                 return True

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -203,7 +203,7 @@ class KernelBuilder(KernelBuilderBase):
         # of reduced_coefficients the integral requires.
         for i in range(len(integral_data.enabled_coefficients)):
             if integral_data.enabled_coefficients[i]:
-                coefficient = form_data.function_replace_map[form_data.reduced_coefficients[i]]
+                coefficient = form_data.reduced_coefficients[i]
                 if type(coefficient.ufl_element()) == ufl_MixedElement:
                     split = [Coefficient(FunctionSpace(coefficient.ufl_domain(), element))
                              for element in coefficient.ufl_element().sub_elements()]

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -73,6 +73,13 @@ class KernelBuilder(KernelBuilderBase):
             f, "coordinate_dofs", interior_facet=self.interior_facet)
         self.coefficient_map[f] = expression
 
+    def set_cell_sizes(self, domain):
+        """Prepare cell sizes field.
+
+        :arg domain: :class:`ufl.Domain`
+        """
+        pass
+
     def set_coefficients(self, integral_data, form_data):
         """Prepare the coefficients of the form.
 
@@ -148,6 +155,15 @@ class KernelBuilder(KernelBuilderBase):
     def needs_cell_orientations(ir):
         # UFC tabulate_tensor always have cell orientations
         return True
+
+    @staticmethod
+    def require_cell_sizes():
+        pass
+
+    @staticmethod
+    def needs_cell_sizes(ir):
+        # Not hooked up right now.
+        return False
 
     def create_element(self, element, **kwargs):
         """Create a FInAT element (suitable for tabulating with) given


### PR DESCRIPTION
This enables FInAT to correctly tabulate Bell, Argyris, Hermite, and Morley elements.

Only affine mappings on triangles for now.  Uses theory of Kirby 2018.