### PR TITLE
Support physically mapped elements in compile_expression_at_points

### DIFF
--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -30,12 +30,12 @@ from gem.optimise import ffc_rounding
 from gem.unconcatenate import unconcatenate
 from gem.utils import cached_property
 
-from finat.physically_mapped import PhysicalGeometry
+from finat.physically_mapped import PhysicalGeometry, PhysicallyMappedElement
 from finat.point_set import PointSet, PointSingleton
 from finat.quadrature import make_quadrature
 
 from tsfc import ufl2gem
-from tsfc.finatinterface import as_fiat_cell
+from tsfc.finatinterface import as_fiat_cell, create_element
 from tsfc.kernel_interface import ProxyKernelInterface
 from tsfc.modified_terminals import (analyse_modified_terminal,
                                      construct_modified_terminal)
@@ -180,6 +180,14 @@ class CoordinateMapping(PhysicalGeometry):
         config.update(self.config)
         context = PointSetContext(**config)
         return map_expr_dag(context.translator, expr)
+
+
+def needs_coordinate_mapping(element):
+    """Does this UFL element require a CoordinateMapping for translation?"""
+    if element.family() == 'Real':
+        return False
+    else:
+        return isinstance(create_element(element), PhysicallyMappedElement)
 
 
 class PointSetContext(ContextBase):

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -59,6 +59,8 @@ class KernelBuilderBase(KernelInterface):
                                                gem.Literal(numpy.nan)))
 
     def cell_size(self, restriction):
+        if not hasattr(self, "_cell_sizes"):
+            raise RuntimeError("Haven't called set_cell_sizes")
         f = {None: (), '+': (0, ), '-': (1, )}[restriction]
         # cell_sizes expression must have been set up by now.
         return gem.partial_indexed(self._cell_sizes, f)


### PR DESCRIPTION
We just need to hook up the same cell size and stuff, and ensure that
we provide coordinates.

Some of this stuff is starting to look ripe for a little refactoring, but I have not done so here.