### PR TITLE
Wence/builder interface

### DIFF
--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -242,12 +242,17 @@ class KernelBuilder(KernelBuilderBase):
         # of reduced_coefficients the integral requires.
         for i in range(len(integral_data.enabled_coefficients)):
             if integral_data.enabled_coefficients[i]:
-                coefficient = form_data.function_replace_map[form_data.reduced_coefficients[i]]
-                if type(coefficient.ufl_element()) == ufl_MixedElement and coefficient not in self.dont_split:
-                    split = [Coefficient(FunctionSpace(coefficient.ufl_domain(), element))
-                             for element in coefficient.ufl_element().sub_elements()]
-                    coefficients.extend(split)
-                    self.coefficient_split[coefficient] = split
+                original = form_data.reduced_coefficients[i]
+                coefficient = form_data.function_replace_map[original]
+                if type(coefficient.ufl_element()) == ufl_MixedElement:
+                    if original in self.dont_split:
+                        coefficients.append(coefficient)
+                        self.coefficient_split[coefficient] = [coefficient]
+                    else:
+                        split = [Coefficient(FunctionSpace(coefficient.ufl_domain(), element))
+                                 for element in coefficient.ufl_element().sub_elements()]
+                        coefficients.extend(split)
+                        self.coefficient_split[coefficient] = split
                 else:
                     coefficients.append(coefficient)
                 # This is which coefficient in the original form the


### PR DESCRIPTION
This changes the interface to compile_form to pass an interface class, rather than a module. Simplifies code in PCPatch in Firedrake.