### PR TITLE
Tighten classifier for delta elimination

### DIFF
--- a/tests/test_tsfc_182.py
+++ b/tests/test_tsfc_182.py
@@ -1,0 +1,33 @@
+import pytest
+
+from ufl import (Coefficient, FiniteElement, MixedElement,
+                 TestFunction, VectorElement, dx, inner, tetrahedron)
+
+from tsfc import compile_form
+
+
+@pytest.mark.parametrize('mode', ['vanilla', 'coffee', 'spectral'])
+def test_delta_elimination(mode):
+    # Code sample courtesy of Marco Morandini:
+    # https://github.com/firedrakeproject/tsfc/issues/182
+    scheme = "default"
+    degree = 3
+
+    element_lambda = FiniteElement("Quadrature", tetrahedron, degree,
+                                   quad_scheme=scheme)
+    element_eps_p = VectorElement("Quadrature", tetrahedron, degree,
+                                  dim=6, quad_scheme=scheme)
+
+    element_chi_lambda = MixedElement(element_eps_p, element_lambda)
+
+    chi_lambda = Coefficient(element_chi_lambda)
+    delta_chi_lambda = TestFunction(element_chi_lambda)
+
+    L = inner(delta_chi_lambda, chi_lambda) * dx(degree=degree, scheme=scheme)
+    kernel, = compile_form(L, parameters={'mode': mode})
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    pytest.main(args=[os.path.abspath(__file__)] + sys.argv[1:])

--- a/tsfc/coffee_mode.py
+++ b/tsfc/coffee_mode.py
@@ -1,6 +1,6 @@
 from functools import partial, reduce
 
-from gem.node import traversal
+from gem.node import traversal, Memoizer
 from gem.gem import Failure, Sum, index_sum
 from gem.optimise import replace_division, unroll_indexsum
 from gem.refactorise import collect_monomials
@@ -75,6 +75,7 @@ def optimise_expressions(expressions, argument_indices):
             return expressions
 
     # Apply argument factorisation unconditionally
-    classifier = partial(spectral.classify, set(argument_indices))
+    classifier = partial(spectral.classify, set(argument_indices),
+                         delta_inside=Memoizer(spectral._delta_inside))
     monomial_sums = collect_monomials(expressions, classifier)
     return [optimise_monomial_sum(ms, argument_indices) for ms in monomial_sums]


### PR DESCRIPTION
If we have a Delta node inside a ListTensor, we can't consider an
Indexed node to be ATOMIC. Fixes #182.

Basically @miklos1's patch, but with a Memoizer. Seems to work for @mmorandi's example.