### PR TITLE
Safe refactorisation of Conditional nodes

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -408,7 +408,7 @@ class Conditional(Node):
 
     def __new__(cls, condition, then, else_):
         assert not condition.shape
-        assert then.shape == else_.shape
+        assert then.shape == else_.shape == ()
 
         # If both branches are the same, just return one of them.  In
         # particular, this will help constant-fold zeros.


### PR DESCRIPTION
Resolves #183.  Needs automatic testing, but I think that is better done through Firedrake, where the generated code can be executed so that verify the lack of `NaN`s in the result.