### PR TITLE
Defer loopy import

### DIFF
--- a/tests/test_flexibly_indexed.py
+++ b/tests/test_flexibly_indexed.py
@@ -5,6 +5,7 @@ import pytest
 
 import gem
 import tsfc
+import tsfc.coffee
 
 
 parameters = tsfc.coffee.Bunch()

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -28,9 +28,6 @@ from tsfc.fiatinterface import as_fiat_cell
 from tsfc.logging import logger
 from tsfc.parameters import default_parameters, is_complex
 
-import tsfc.kernel_interface.firedrake as firedrake_interface_coffee
-import tsfc.kernel_interface.firedrake_loopy as firedrake_interface_loopy
-
 # To handle big forms. The various transformations might need a deeper stack
 sys.setrecursionlimit(3000)
 
@@ -90,8 +87,10 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, co
         parameters = _
     if interface is None:
         if coffee:
+            import tsfc.kernel_interface.firedrake as firedrake_interface_coffee
             interface = firedrake_interface_coffee.KernelBuilder
         else:
+            import tsfc.kernel_interface.firedrake_loopy as firedrake_interface_loopy
             interface = firedrake_interface_loopy.KernelBuilder
 
     # Remove these here, they're handled below.
@@ -293,8 +292,10 @@ def compile_expression_at_points(expression, points, coordinates, interface=None
     # Initialise kernel builder
     if interface is None:
         if coffee:
+            import tsfc.kernel_interface.firedrake as firedrake_interface_coffee
             interface = firedrake_interface_coffee.ExpressionKernelBuilder
         else:
+            import tsfc.kernel_interface.firedrake_loopy as firedrake_interface_loopy
             interface = firedrake_interface_loopy.ExpressionKernelBuilder
 
     builder = interface(parameters["scalar_type"])

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -90,6 +90,7 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, co
             import tsfc.kernel_interface.firedrake as firedrake_interface_coffee
             interface = firedrake_interface_coffee.KernelBuilder
         else:
+            # Delayed import, loopy is a runtime dependency
             import tsfc.kernel_interface.firedrake_loopy as firedrake_interface_loopy
             interface = firedrake_interface_loopy.KernelBuilder
 
@@ -295,6 +296,7 @@ def compile_expression_at_points(expression, points, coordinates, interface=None
             import tsfc.kernel_interface.firedrake as firedrake_interface_coffee
             interface = firedrake_interface_coffee.ExpressionKernelBuilder
         else:
+            # Delayed import, loopy is a runtime dependency
             import tsfc.kernel_interface.firedrake_loopy as firedrake_interface_loopy
             interface = firedrake_interface_loopy.ExpressionKernelBuilder
 


### PR DESCRIPTION
Do not put loopy import as top-level statement. No actual need to install loopy when only ufc kernel interface is used.