### PR TITLE
L2pullbacks

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,5 +1,5 @@
 git+https://github.com/coneoproject/COFFEE.git#egg=coffee
-git+https://github.com/firedrakeproject/ufl.git@l2pullbacks#egg=ufl
+git+https://github.com/firedrakeproject/ufl.git#egg=ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
 git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,5 +1,5 @@
 git+https://github.com/coneoproject/COFFEE.git#egg=coffee
-git+https://github.com/firedrakeproject/ufl.git#egg=ufl
+git+https://github.com/firedrakeproject/ufl.git#egg=ufl@l2pullbacks
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
 git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,5 +1,5 @@
 git+https://github.com/coneoproject/COFFEE.git#egg=coffee
-git+https://github.com/firedrakeproject/ufl.git#egg=ufl@l2pullbacks
+git+https://github.com/firedrakeproject/ufl.git@l2pullbacks#egg=ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
 git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy

--- a/tests/test_create_fiat_element.py
+++ b/tests/test_create_fiat_element.py
@@ -86,10 +86,12 @@ def test_triangle_variant_spectral_fail():
     with pytest.raises(ValueError):
         create_element(ufl_element)
 
+
 def test_triangle_variant_spectral_fail_l2():
     ufl_element = ufl.FiniteElement('DP L2', ufl.triangle, 2, variant='spectral')
     with pytest.raises(ValueError):
         create_element(ufl_element)
+
 
 def test_quadrilateral_variant_spectral_q():
     element = create_element(ufl.FiniteElement('Q', ufl.quadrilateral, 3, variant='spectral'))
@@ -102,10 +104,12 @@ def test_quadrilateral_variant_spectral_dq():
     assert isinstance(element.element.A, FIAT.GaussLegendre)
     assert isinstance(element.element.B, FIAT.GaussLegendre)
 
+
 def test_quadrilateral_variant_spectral_dq_l2():
     element = create_element(ufl.FiniteElement('DQ L2', ufl.quadrilateral, 1, variant='spectral'))
     assert isinstance(element.element.A, FIAT.GaussLegendre)
     assert isinstance(element.element.B, FIAT.GaussLegendre)
+
 
 def test_quadrilateral_variant_spectral_rtcf():
     element = create_element(ufl.FiniteElement('RTCF', ufl.quadrilateral, 2, variant='spectral'))

--- a/tests/test_create_fiat_element.py
+++ b/tests/test_create_fiat_element.py
@@ -29,7 +29,7 @@ def test_triangle_basic(ufl_element):
     assert isinstance(element, supported_elements[ufl_element.family()])
 
 
-@pytest.fixture(params=["CG", "DG"], scope="module")
+@pytest.fixture(params=["CG", "DG", "DG L2"], scope="module")
 def tensor_name(request):
     return request.param
 
@@ -62,7 +62,8 @@ def test_tensor_prod_simple(ufl_A, ufl_B):
 
 @pytest.mark.parametrize(('family', 'expected_cls'),
                          [('P', FIAT.Lagrange),
-                          ('DP', FIAT_DiscontinuousLagrange)])
+                          ('DP', FIAT_DiscontinuousLagrange),
+                          ('DP L2', FIAT_DiscontinuousLagrange)])
 def test_interval_variant_default(family, expected_cls):
     ufl_element = ufl.FiniteElement(family, ufl.interval, 3)
     assert isinstance(create_element(ufl_element), expected_cls)
@@ -72,7 +73,9 @@ def test_interval_variant_default(family, expected_cls):
                          [('P', 'equispaced', FIAT.Lagrange),
                           ('P', 'spectral', FIAT.GaussLobattoLegendre),
                           ('DP', 'equispaced', FIAT_DiscontinuousLagrange),
-                          ('DP', 'spectral', FIAT.GaussLegendre)])
+                          ('DP', 'spectral', FIAT.GaussLegendre),
+                          ('DP L2', 'equispaced', FIAT_DiscontinuousLagrange),
+                          ('DP L2', 'spectral', FIAT.GaussLegendre)])
 def test_interval_variant(family, variant, expected_cls):
     ufl_element = ufl.FiniteElement(family, ufl.interval, 3, variant=variant)
     assert isinstance(create_element(ufl_element), expected_cls)
@@ -83,6 +86,10 @@ def test_triangle_variant_spectral_fail():
     with pytest.raises(ValueError):
         create_element(ufl_element)
 
+def test_triangle_variant_spectral_fail_l2():
+    ufl_element = ufl.FiniteElement('DP L2', ufl.triangle, 2, variant='spectral')
+    with pytest.raises(ValueError):
+        create_element(ufl_element)
 
 def test_quadrilateral_variant_spectral_q():
     element = create_element(ufl.FiniteElement('Q', ufl.quadrilateral, 3, variant='spectral'))
@@ -95,6 +102,10 @@ def test_quadrilateral_variant_spectral_dq():
     assert isinstance(element.element.A, FIAT.GaussLegendre)
     assert isinstance(element.element.B, FIAT.GaussLegendre)
 
+def test_quadrilateral_variant_spectral_dq_l2():
+    element = create_element(ufl.FiniteElement('DQ L2', ufl.quadrilateral, 1, variant='spectral'))
+    assert isinstance(element.element.A, FIAT.GaussLegendre)
+    assert isinstance(element.element.B, FIAT.GaussLegendre)
 
 def test_quadrilateral_variant_spectral_rtcf():
     element = create_element(ufl.FiniteElement('RTCF', ufl.quadrilateral, 2, variant='spectral'))

--- a/tests/test_create_finat_element.py
+++ b/tests/test_create_finat_element.py
@@ -94,10 +94,12 @@ def test_triangle_variant_spectral_fail():
     with pytest.raises(ValueError):
         create_element(ufl_element)
 
+
 def test_triangle_variant_spectral_fail_l2():
     ufl_element = ufl.FiniteElement('DP L2', ufl.triangle, 2, variant='spectral')
     with pytest.raises(ValueError):
         create_element(ufl_element)
+
 
 def test_quadrilateral_variant_spectral_q():
     element = create_element(ufl.FiniteElement('Q', ufl.quadrilateral, 3, variant='spectral'))
@@ -110,10 +112,12 @@ def test_quadrilateral_variant_spectral_dq():
     assert isinstance(element.product.factors[0], finat.GaussLegendre)
     assert isinstance(element.product.factors[1], finat.GaussLegendre)
 
+
 def test_quadrilateral_variant_spectral_dq_l2():
     element = create_element(ufl.FiniteElement('DQ L2', ufl.quadrilateral, 1, variant='spectral'))
     assert isinstance(element.product.factors[0], finat.GaussLegendre)
     assert isinstance(element.product.factors[1], finat.GaussLegendre)
+
 
 def test_cache_hit(ufl_element):
     A = create_element(ufl_element)

--- a/tests/test_create_finat_element.py
+++ b/tests/test_create_finat_element.py
@@ -39,7 +39,7 @@ def test_triangle_vector(ufl_element, ufl_vector_element):
     assert scalar == vector.base_element
 
 
-@pytest.fixture(params=["CG", "DG"])
+@pytest.fixture(params=["CG", "DG", "DG L2"])
 def tensor_name(request):
     return request.param
 
@@ -70,7 +70,8 @@ def test_tensor_prod_simple(ufl_A, ufl_B):
 
 @pytest.mark.parametrize(('family', 'expected_cls'),
                          [('P', finat.Lagrange),
-                          ('DP', finat.DiscontinuousLagrange)])
+                          ('DP', finat.DiscontinuousLagrange),
+                          ('DP L2', finat.DiscontinuousLagrange)])
 def test_interval_variant_default(family, expected_cls):
     ufl_element = ufl.FiniteElement(family, ufl.interval, 3)
     assert isinstance(create_element(ufl_element), expected_cls)
@@ -80,7 +81,9 @@ def test_interval_variant_default(family, expected_cls):
                          [('P', 'equispaced', finat.Lagrange),
                           ('P', 'spectral', finat.GaussLobattoLegendre),
                           ('DP', 'equispaced', finat.DiscontinuousLagrange),
-                          ('DP', 'spectral', finat.GaussLegendre)])
+                          ('DP', 'spectral', finat.GaussLegendre),
+                          ('DP L2', 'equispaced', finat.DiscontinuousLagrange),
+                          ('DP L2', 'spectral', finat.GaussLegendre)])
 def test_interval_variant(family, variant, expected_cls):
     ufl_element = ufl.FiniteElement(family, ufl.interval, 3, variant=variant)
     assert isinstance(create_element(ufl_element), expected_cls)
@@ -91,6 +94,10 @@ def test_triangle_variant_spectral_fail():
     with pytest.raises(ValueError):
         create_element(ufl_element)
 
+def test_triangle_variant_spectral_fail_l2():
+    ufl_element = ufl.FiniteElement('DP L2', ufl.triangle, 2, variant='spectral')
+    with pytest.raises(ValueError):
+        create_element(ufl_element)
 
 def test_quadrilateral_variant_spectral_q():
     element = create_element(ufl.FiniteElement('Q', ufl.quadrilateral, 3, variant='spectral'))
@@ -103,6 +110,10 @@ def test_quadrilateral_variant_spectral_dq():
     assert isinstance(element.product.factors[0], finat.GaussLegendre)
     assert isinstance(element.product.factors[1], finat.GaussLegendre)
 
+def test_quadrilateral_variant_spectral_dq_l2():
+    element = create_element(ufl.FiniteElement('DQ L2', ufl.quadrilateral, 1, variant='spectral'))
+    assert isinstance(element.product.factors[0], finat.GaussLegendre)
+    assert isinstance(element.product.factors[1], finat.GaussLegendre)
 
 def test_cache_hit(ufl_element):
     A = create_element(ufl_element)

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -61,7 +61,11 @@ supported_elements = {
     "NCE": None,
     "NCF": None,
     "DPC": FIAT.DPC,
-    "S": FIAT.Serendipity
+    "S": FIAT.Serendipity,
+    "DPC L2": FIAT.DPC,
+    "Discontinuous Lagrange L2": FIAT.DiscontinuousLagrange,
+    "Gauss-Legendre L2": FIAT.GaussLegendre,
+    "DQ L2": None,
 }
 """A :class:`.dict` mapping UFL element family names to their
 FIAT-equivalent constructors.  If the value is ``None``, the UFL
@@ -133,14 +137,14 @@ def convert_finiteelement(element, vector_is_mixed):
             lmbda = FIAT.GaussLobattoLegendre
         else:
             raise ValueError("Variant %r not supported on %s" % (kind, element.cell()))
-    elif element.family() == "Discontinuous Lagrange":
+    elif element.family() in ["Discontinuous Lagrange", "Discontinuous Lagrange L2"]:
         if kind == 'equispaced':
             lmbda = FIAT.DiscontinuousLagrange
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = FIAT.GaussLegendre
         else:
             raise ValueError("Variant %r not supported on %s" % (kind, element.cell()))
-    elif element.family() == "DPC":
+    elif element.family() in ["DPC", "DPC L2"]:
         if element.cell().geometric_dimension() == 2:
             element = element.reconstruct(cell=ufl.hypercube(2))
         elif element.cell.geometric_dimension() == 3:

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -66,7 +66,11 @@ supported_elements = {
     "NCF": None,
     "Real": finat.DiscontinuousLagrange,
     "DPC": finat.DPC,
-    "S": finat.Serendipity
+    "S": finat.Serendipity,
+    "DPC L2": finat.DPC,
+    "Discontinuous Lagrange L2": finat.DiscontinuousLagrange,
+    "Gauss-Legendre L2": finat.GaussLegendre,
+    "DQ L2": None,
 }
 """A :class:`.dict` mapping UFL element family names to their
 FInAT-equivalent constructors.  If the value is ``None``, the UFL
@@ -139,7 +143,7 @@ def convert_finiteelement(element, **kwargs):
             return finat.RuntimeTabulated(cell, degree, variant=kind, shift_axes=shift_axes, restriction=restriction), deps
         else:
             raise ValueError("Variant %r not supported on %s" % (kind, element.cell()))
-    elif element.family() == "Discontinuous Lagrange":
+    elif element.family() in ["Discontinuous Lagrange", "Discontinuous Lagrange L2"]:
         kind = element.variant() or 'equispaced'
         if kind == 'equispaced':
             lmbda = finat.DiscontinuousLagrange
@@ -153,7 +157,7 @@ def convert_finiteelement(element, **kwargs):
             return finat.RuntimeTabulated(cell, degree, variant=kind, shift_axes=shift_axes, restriction=restriction, continuous=False), deps
         else:
             raise ValueError("Variant %r not supported on %s" % (kind, element.cell()))
-    elif element.family() == "DPC":
+    elif element.family() == ["DPC", "DPC L2"]:
         if element.cell().geometric_dimension() == 2:
             element = element.reconstruct(cell=ufl.cell.hypercube(2))
         elif element.cell().geometric_dimension() == 3:


### PR DESCRIPTION
This adds proper L2 pullbacks (ie integral-preserving, designed for n-forms), by defining new elements at the UFL level and introducing an "L2 Piola" mapping. These elements then share the same FIAT/FiNAT classes as the original elements, since from the perspective of the tabulator the pullback doesn't matter.

Requires https://github.com/firedrakeproject/firedrake/pull/1463 and https://github.com/FEniCS/ufl/pull/4