### PR TITLE
Remove hypercube cell reconstruction calls for Serendipity elements

### DIFF
--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -144,17 +144,6 @@ def convert_finiteelement(element, vector_is_mixed):
             lmbda = FIAT.GaussLegendre
         else:
             raise ValueError("Variant %r not supported on %s" % (kind, element.cell()))
-    elif element.family() in ["DPC", "DPC L2"]:
-        if element.cell().geometric_dimension() == 2:
-            element = element.reconstruct(cell=ufl.hypercube(2))
-        elif element.cell.geometric_dimension() == 3:
-            element = element.reconstruct(cell=ufl.hypercube(3))
-    elif element.family() == "S":
-        if element.cell().geometric_dimension() == 2:
-            element = element.reconstruct(cell=ufl.hypercube(2))
-        elif element.cell().geometric_dimension() == 3:
-            element = element.reconstruct(cell=ufl.hypercube(3))
-
     return lmbda(cell, element.degree())
 
 


### PR DESCRIPTION
The reference element is handled correctly in FIAT; we don't need TSFC to do anything extra or special case these elements.