### PR TITLE
Drop compatibility with non complex ready Firedrake

### DIFF
--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -15,15 +15,12 @@ from gem import gem, impero as imp
 
 from tsfc.parameters import is_complex
 
-# Satisfy import demands until complex branch is merged in Firedrake
-from tsfc.parameters import SCALAR_TYPE
-
 
 class Bunch(object):
     pass
 
 
-def generate(impero_c, index_names, precision, scalar_type=None):
+def generate(impero_c, index_names, precision, scalar_type):
     """Generates COFFEE code.
 
     :arg impero_c: ImperoC tuple with Impero AST and other data
@@ -37,7 +34,7 @@ def generate(impero_c, index_names, precision, scalar_type=None):
     params.indices = impero_c.indices
     params.precision = precision
     params.epsilon = 10.0 * eval("1e-%d" % precision)
-    params.scalar_type = scalar_type or SCALAR_TYPE
+    params.scalar_type = scalar_type
 
     params.names = {}
     for i, temp in enumerate(impero_c.temporaries):

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -60,14 +60,11 @@ class Kernel(object):
 
 class KernelBuilderBase(_KernelBuilderBase):
 
-    def __init__(self, scalar_type=None, interior_facet=False):
+    def __init__(self, scalar_type, interior_facet=False):
         """Initialise a kernel builder.
 
         :arg interior_facet: kernel accesses two cells
         """
-        if scalar_type is None:
-            from tsfc.parameters import SCALAR_TYPE
-            scalar_type = SCALAR_TYPE
         super(KernelBuilderBase, self).__init__(scalar_type=scalar_type,
                                                 interior_facet=interior_facet)
 
@@ -173,7 +170,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
 class KernelBuilder(KernelBuilderBase):
     """Helper class for building a :class:`Kernel` object."""
 
-    def __init__(self, integral_type, subdomain_id, domain_number, scalar_type=None,
+    def __init__(self, integral_type, subdomain_id, domain_number, scalar_type,
                  dont_split=()):
         """Initialise a kernel builder."""
         super(KernelBuilder, self).__init__(scalar_type, integral_type.startswith("interior_facet"))

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -19,9 +19,6 @@ from pytools import UniqueNameGenerator
 
 from tsfc.parameters import is_complex
 
-# Satisfy import demands until complex branch is merged in Firedrake
-from tsfc.parameters import SCALAR_TYPE
-
 
 class LoopyContext(object):
     def __init__(self):
@@ -64,7 +61,7 @@ class LoopyContext(object):
         return frozenset([i.name for i in self.active_indices.values()])
 
 
-def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=[], scalar_type=None):
+def generate(impero_c, args, precision, scalar_type, kernel_name="loopy_kernel", index_names=[]):
     """Generates loopy code.
 
     :arg impero_c: ImperoC tuple with Impero AST and other data
@@ -79,7 +76,7 @@ def generate(impero_c, args, precision, kernel_name="loopy_kernel", index_names=
     ctx.indices = impero_c.indices
     ctx.index_names = defaultdict(lambda: "i", index_names)
     ctx.precision = precision
-    ctx.scalar_type = scalar_type or SCALAR_TYPE
+    ctx.scalar_type = scalar_type
     ctx.epsilon = 10.0 ** (-precision)
 
     # Create arguments

--- a/tsfc/parameters.py
+++ b/tsfc/parameters.py
@@ -21,9 +21,6 @@ PARAMETERS = {
     "precision": numpy.finfo(numpy.dtype("double")).precision,
 }
 
-# Satisfy import demands until complex branch is merged in Firedrake
-SCALAR_TYPE = PARAMETERS["scalar_type"]
-
 
 def default_parameters():
     return PARAMETERS.copy()


### PR DESCRIPTION
This reverts commit 4922cf0 and updates new loopy code accordingly.

Depends on firedrakeproject/firedrake#1491 to not break Firedrake.