### PR TITLE
Translation of gem's ComponentTensors/Solve/Inverse into loops in loopy.

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -562,7 +562,7 @@ class FlexiblyIndexed(Scalar):
     def __init__(self, variable, dim2idxs):
         """Construct a flexibly indexed node.
 
-        :arg variable: a :py:class:`Variable`
+        :arg variable: a node that has a shape
         :arg dim2idxs: describes the mapping of indices
 
         For example, if ``variable`` is rank two, and ``dim2idxs`` is
@@ -574,7 +574,7 @@ class FlexiblyIndexed(Scalar):
             variable[1 + i*12 + j*4 + k][0]
 
         """
-        assert isinstance(variable, Variable)
+        assert variable.shape
         assert len(variable.shape) == len(dim2idxs)
 
         dim2idxs_ = []

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -10,7 +10,7 @@ import numpy
 from gem.utils import groupby
 from gem.node import (Memoizer, MemoizerArg, reuse_if_untouched,
                       reuse_if_untouched_arg, traversal)
-from gem.gem import (Node, Terminal, Failure, Identity, Literal, Zero,
+from gem.gem import (Node, Failure, Identity, Literal, Zero,
                      Product, Sum, Comparison, Conditional, Division,
                      Index, VariableIndex, Indexed, FlexiblyIndexed,
                      IndexSum, ComponentTensor, ListTensor, Delta,
@@ -128,7 +128,6 @@ def replace_indices_indexed(node, self, subst):
 @replace_indices.register(FlexiblyIndexed)
 def replace_indices_flexiblyindexed(node, self, subst):
     child, = node.children
-    assert isinstance(child, Terminal)
     assert not child.free_indices
 
     substitute = dict(subst)

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -157,7 +157,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
             args.append(self.cell_sizes_arg)
         args.extend(self.kernel_args)
 
-        body = generate_coffee(impero_c, index_names, precision)
+        body = generate_coffee(impero_c, index_names, precision, self.scalar_type)
 
         for name_, shape in self.tabulations:
             args.append(coffee.Decl(self.scalar_type, coffee.Symbol(


### PR DESCRIPTION
Slate has global operations on matrices, which ufl has not. In the two stage slate translation, we compile slate to gem to loopy. For the gem to loopy stage we need to allow ComponentTensors to be resolved later in the compilation process. In order to do so, we need to introduce how to compile this gem structure into a loopy structure. My suggestion here is to treat ComponentTensor like a loop.