### PR TITLE
Fix tsfc bug #208.

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -366,6 +366,7 @@ def compile_expression_dual_evaluation(expression, to_element, coordinates, inte
         # Allow interpolation onto QuadratureElements to refer to the quadrature
         # rule they represent
         if isinstance(to_element, FIAT.QuadratureElement):
+            assert all(qpoints == to_element._points)
             quad_rule = QuadratureRule(point_set, to_element._weights)
             config["quadrature_rule"] = quad_rule
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -18,11 +18,12 @@ from ufl.utils.sequences import max_degree
 import gem
 import gem.impero_utils as impero_utils
 
+import FIAT
 from FIAT.reference_element import TensorProductCell
 from FIAT.functional import PointEvaluation
 
 from finat.point_set import PointSet
-from finat.quadrature import AbstractQuadratureRule, make_quadrature
+from finat.quadrature import AbstractQuadratureRule, make_quadrature, QuadratureRule
 
 from tsfc import fem, ufl_utils
 from tsfc.fiatinterface import as_fiat_cell
@@ -361,6 +362,12 @@ def compile_expression_dual_evaluation(expression, to_element, coordinates, inte
         point_set = PointSet(qpoints)
         config = kernel_cfg.copy()
         config.update(point_set=point_set)
+
+        # Fix for interpolating QuadratureWeight into a QuadratureElement
+        if isinstance(to_element, FIAT.QuadratureElement):
+            quad_rule = QuadratureRule(point_set, to_element._weights)
+            config["quadrature_rule"] = quad_rule
+
         expr, = fem.compile_ufl(expression, **config, point_sum=False)
         shape_indices = tuple(gem.Index() for _ in expr.shape)
         basis_indices = point_set.indices

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -363,7 +363,8 @@ def compile_expression_dual_evaluation(expression, to_element, coordinates, inte
         config = kernel_cfg.copy()
         config.update(point_set=point_set)
 
-        # Fix for interpolating QuadratureWeight into a QuadratureElement
+        # Allow interpolation onto QuadratureElements to refer to the quadrature
+        # rule they represent
         if isinstance(to_element, FIAT.QuadratureElement):
             quad_rule = QuadratureRule(point_set, to_element._weights)
             config["quadrature_rule"] = quad_rule

--- a/tsfc/fiatinterface.py
+++ b/tsfc/fiatinterface.py
@@ -112,7 +112,7 @@ def convert_finiteelement(element, vector_is_mixed):
             raise ValueError("Quadrature scheme and degree must be specified!")
 
         quad_rule = FIAT.create_quadrature(cell, degree, scheme)
-        return FIAT.QuadratureElement(cell, quad_rule.get_points())
+        return FIAT.QuadratureElement(cell, quad_rule.get_points(), weights=quad_rule.get_weights())
     lmbda = supported_elements[element.family()]
     if lmbda is None:
         if element.cell().cellname() == "quadrilateral":


### PR DESCRIPTION
Enables `interpolate(QuadratureWeight(mesh), FunctionSpace(..., QuadratureElement(...)))`.

Depends on https://github.com/FEniCS/fiat/pull/43 .