### PR TITLE
Type-cast everything to numpy arrays in assertion

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -366,7 +366,7 @@ def compile_expression_dual_evaluation(expression, to_element, coordinates, inte
         # Allow interpolation onto QuadratureElements to refer to the quadrature
         # rule they represent
         if isinstance(to_element, FIAT.QuadratureElement):
-            assert all(qpoints == to_element._points)
+            assert (asarray(qpoints) == asarray(to_element._points)).all()
             quad_rule = QuadratureRule(point_set, to_element._weights)
             config["quadrature_rule"] = quad_rule
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -366,7 +366,7 @@ def compile_expression_dual_evaluation(expression, to_element, coordinates, inte
         # Allow interpolation onto QuadratureElements to refer to the quadrature
         # rule they represent
         if isinstance(to_element, FIAT.QuadratureElement):
-            assert (asarray(qpoints) == asarray(to_element._points)).all()
+            assert allclose(asarray(qpoints), asarray(to_element._points))
             quad_rule = QuadratureRule(point_set, to_element._weights)
             config["quadrature_rule"] = quad_rule
 


### PR DESCRIPTION
The assertion we added in review for https://github.com/firedrakeproject/tsfc/pull/210 is too zealous. It fails when one of the operands is a list and the other is a numpy array. [I don't know why this happens in some cases but not in others.] This modifies the assertion to type-cast everything to numpy arrays when checking that the quadrature points all match up.