### PR TITLE
wence/feature/return accumulate

### DIFF
--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -38,12 +38,17 @@ def preprocess_gem(expressions, replace_delta=True, remove_componenttensors=True
     return expressions
 
 
-def compile_gem(assignments, prefix_ordering, remove_zeros=False):
+def compile_gem(assignments, prefix_ordering, remove_zeros=False,
+                emit_return_accumulate=True):
     """Compiles GEM to Impero.
 
     :arg assignments: list of (return variable, expression DAG root) pairs
     :arg prefix_ordering: outermost loop indices
     :arg remove_zeros: remove zero assignment to return variables
+    :arg emit_return_accumulate: emit ReturnAccumulate nodes (see
+         :func:`~.scheduling.emit_operations`)? If False,
+         split into Accumulate/Return pairs. Set to False if the
+         output tensor of kernels is not guaranteed to be zero on entry.
     """
     # Remove zeros
     if remove_zeros:
@@ -69,7 +74,7 @@ def compile_gem(assignments, prefix_ordering, remove_zeros=False):
     get_indices = lambda expr: apply_ordering(expr.free_indices)
 
     # Build operation ordering
-    ops = scheduling.emit_operations(assignments, get_indices)
+    ops = scheduling.emit_operations(assignments, get_indices, emit_return_accumulate)
 
     # Empty kernel
     if len(ops) == 0:

--- a/gem/scheduling.py
+++ b/gem/scheduling.py
@@ -141,7 +141,7 @@ def handle(ops, push, decref, node):
         raise AssertionError("no handler for node type %s" % type(node))
 
 
-def emit_operations(assignments, get_indices):
+def emit_operations(assignments, get_indices, emit_return_accumulate=True):
     """Makes an ordering of operations to evaluate a multi-root
     expression DAG.
 
@@ -150,6 +150,9 @@ def emit_operations(assignments, get_indices):
                       upon execution.
     :arg get_indices: mapping from GEM nodes to an ordering of free
                       indices
+    :arg emit_return_accumulate: emit ReturnAccumulate nodes? Set to
+                      False if the output variables are not guaranteed
+                      zero on entry to the kernel.
     :returns: list of Impero terminals correctly ordered to evaluate
               the assignments
     """
@@ -159,7 +162,8 @@ def emit_operations(assignments, get_indices):
     # Stage return operations
     staging = []
     for variable, expression in assignments:
-        if refcount[expression] == 1 and isinstance(expression, gem.IndexSum) \
+        if emit_return_accumulate and \
+                refcount[expression] == 1 and isinstance(expression, gem.IndexSum) \
                 and set(variable.free_indices) == set(expression.free_indices):
             staging.append(impero.ReturnAccumulate(variable, expression))
             refcount[expression] -= 1

--- a/tsfc/coffee.py
+++ b/tsfc/coffee.py
@@ -20,20 +20,20 @@ class Bunch(object):
     pass
 
 
-def generate(impero_c, index_names, precision, scalar_type):
+def generate(impero_c, index_names, scalar_type):
     """Generates COFFEE code.
 
     :arg impero_c: ImperoC tuple with Impero AST and other data
     :arg index_names: pre-assigned index names
-    :arg precision: floating-point precision for printing
     :arg scalar_type: type of scalars as C typename string
     :returns: COFFEE function body
     """
     params = Bunch()
     params.declare = impero_c.declare
     params.indices = impero_c.indices
-    params.precision = precision
-    params.epsilon = 10.0 * eval("1e-%d" % precision)
+    finfo = numpy.finfo(scalar_type)
+    params.precision = finfo.precision
+    params.epsilon = finfo.resolution
     params.scalar_type = scalar_type
 
     params.names = {}

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -151,12 +151,11 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, co
     kernel_cfg = dict(interface=builder,
                       ufl_cell=cell,
                       integral_type=integral_type,
-                      precision=parameters["precision"],
                       integration_dim=integration_dim,
                       entity_ids=entity_ids,
                       argument_multiindices=argument_multiindices,
                       index_cache=index_cache,
-                      complex_mode=is_complex(parameters.get("scalar_type")))
+                      scalar_type=parameters["scalar_type"])
 
     mode_irs = collections.OrderedDict()
     for integral in integral_data.integrals:
@@ -265,7 +264,7 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, co
     for multiindex, name in zip(argument_multiindices, ['j', 'k']):
         name_multiindex(multiindex, name)
 
-    return builder.construct_kernel(kernel_name, impero_c, parameters["precision"], index_names, quad_rule)
+    return builder.construct_kernel(kernel_name, impero_c, index_names, quad_rule)
 
 
 def compile_expression_dual_evaluation(expression, to_element, coordinates, interface=None,
@@ -341,10 +340,9 @@ def compile_expression_dual_evaluation(expression, to_element, coordinates, inte
     # Translate to GEM
     kernel_cfg = dict(interface=builder,
                       ufl_cell=coordinates.ufl_domain().ufl_cell(),
-                      precision=parameters["precision"],
                       argument_multiindices=argument_multiindices,
                       index_cache={},
-                      complex_mode=complex_mode)
+                      scalar_type=parameters["scalar_type"])
 
     if all(isinstance(dual, PointEvaluation) for dual in to_element.dual_basis()):
         # This is an optimisation for point-evaluation nodes which
@@ -426,7 +424,7 @@ def compile_expression_dual_evaluation(expression, to_element, coordinates, inte
     # Handle kernel interface requirements
     builder.register_requirements([ir])
     # Build kernel tuple
-    return builder.construct_kernel(return_arg, impero_c, parameters["precision"], index_names)
+    return builder.construct_kernel(return_arg, impero_c, index_names)
 
 
 def lower_integral_type(fiat_cell, integral_type):

--- a/tsfc/kernel_interface/firedrake.py
+++ b/tsfc/kernel_interface/firedrake.py
@@ -143,7 +143,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         provided by the kernel interface."""
         self.oriented, self.cell_sizes, self.tabulations = check_requirements(ir)
 
-    def construct_kernel(self, return_arg, impero_c, precision, index_names):
+    def construct_kernel(self, return_arg, impero_c, index_names):
         """Constructs an :class:`ExpressionKernel`.
 
         :arg return_arg: COFFEE argument for the return value
@@ -157,7 +157,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
             args.append(self.cell_sizes_arg)
         args.extend(self.kernel_args)
 
-        body = generate_coffee(impero_c, index_names, precision, self.scalar_type)
+        body = generate_coffee(impero_c, index_names, self.scalar_type)
 
         for name_, shape in self.tabulations:
             args.append(coffee.Decl(self.scalar_type, coffee.Symbol(
@@ -260,7 +260,7 @@ class KernelBuilder(KernelBuilderBase):
         knl = self.kernel
         knl.oriented, knl.needs_cell_sizes, knl.tabulations = check_requirements(ir)
 
-    def construct_kernel(self, name, impero_c, precision, index_names, quadrature_rule):
+    def construct_kernel(self, name, impero_c, index_names, quadrature_rule):
         """Construct a fully built :class:`Kernel`.
 
         This function contains the logic for building the argument
@@ -268,13 +268,12 @@ class KernelBuilder(KernelBuilderBase):
 
         :arg name: function name
         :arg impero_c: ImperoC tuple with Impero AST and other data
-        :arg precision: floating-point precision for printing
         :arg index_names: pre-assigned index names
         :arg quadrature rule: quadrature rule
 
         :returns: :class:`Kernel` object
         """
-        body = generate_coffee(impero_c, index_names, precision, self.scalar_type)
+        body = generate_coffee(impero_c, index_names, self.scalar_type)
 
         args = [self.local_tensor, self.coordinates_arg]
         if self.kernel.oriented:

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -146,12 +146,11 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         provided by the kernel interface."""
         self.oriented, self.cell_sizes, self.tabulations = check_requirements(ir)
 
-    def construct_kernel(self, return_arg, impero_c, precision, index_names):
+    def construct_kernel(self, return_arg, impero_c, index_names):
         """Constructs an :class:`ExpressionKernel`.
 
         :arg return_arg: loopy.GlobalArg for the return value
         :arg impero_c: gem.ImperoC object that represents the kernel
-        :arg precision: floating point precision for code generation
         :arg index_names: pre-assigned index names
         :returns: :class:`ExpressionKernel` object
         """
@@ -164,7 +163,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         for name_, shape in self.tabulations:
             args.append(lp.GlobalArg(name_, dtype=self.scalar_type, shape=shape))
 
-        loopy_kernel = generate_loopy(impero_c, args, precision, self.scalar_type,
+        loopy_kernel = generate_loopy(impero_c, args, self.scalar_type,
                                       "expression_kernel", index_names)
         return ExpressionKernel(loopy_kernel, self.oriented, self.cell_sizes,
                                 self.coefficients, self.tabulations)
@@ -263,7 +262,7 @@ class KernelBuilder(KernelBuilderBase):
         knl = self.kernel
         knl.oriented, knl.needs_cell_sizes, knl.tabulations = check_requirements(ir)
 
-    def construct_kernel(self, name, impero_c, precision, index_names, quadrature_rule):
+    def construct_kernel(self, name, impero_c, index_names, quadrature_rule):
         """Construct a fully built :class:`Kernel`.
 
         This function contains the logic for building the argument
@@ -271,7 +270,6 @@ class KernelBuilder(KernelBuilderBase):
 
         :arg name: function name
         :arg impero_c: ImperoC tuple with Impero AST and other data
-        :arg precision: floating-point precision for printing
         :arg index_names: pre-assigned index names
         :arg quadrature rule: quadrature rule
         :returns: :class:`Kernel` object
@@ -292,8 +290,7 @@ class KernelBuilder(KernelBuilderBase):
             args.append(lp.GlobalArg(name_, dtype=self.scalar_type, shape=shape))
 
         self.kernel.quadrature_rule = quadrature_rule
-        self.kernel.ast = generate_loopy(impero_c, args, precision,
-                                         self.scalar_type, name, index_names)
+        self.kernel.ast = generate_loopy(impero_c, args, self.scalar_type, name, index_names)
         return self.kernel
 
     def construct_empty_kernel(self, name):

--- a/tsfc/kernel_interface/ufc.py
+++ b/tsfc/kernel_interface/ufc.py
@@ -104,7 +104,7 @@ class KernelBuilder(KernelBuilderBase):
             expression = prepare_coefficient(coefficient, n, name, self.interior_facet)
             self.coefficient_map[coefficient] = expression
 
-    def construct_kernel(self, name, impero_c, precision, index_names, quadrature_rule=None):
+    def construct_kernel(self, name, impero_c, index_names, quadrature_rule=None):
         """Construct a fully built kernel function.
 
         This function contains the logic for building the argument
@@ -112,13 +112,12 @@ class KernelBuilder(KernelBuilderBase):
 
         :arg name: function name
         :arg impero_c: ImperoC tuple with Impero AST and other data
-        :arg precision: floating-point precision for printing
         :arg index_names: pre-assigned index names
         :arg quadrature rule: quadrature rule (not used, stubbed out for Themis integration)
         :returns: a COFFEE function definition object
         """
         from tsfc.coffee import generate as generate_coffee
-        body = generate_coffee(impero_c, index_names, precision, scalar_type=self.scalar_type)
+        body = generate_coffee(impero_c, index_names, scalar_type=self.scalar_type)
         return self._construct_kernel_from_body(name, body)
 
     def _construct_kernel_from_body(self, name, body, quadrature_rule):

--- a/tsfc/parameters.py
+++ b/tsfc/parameters.py
@@ -19,9 +19,6 @@ PARAMETERS = {
 
     # So that tests pass (needs to match scalar_type)
     "scalar_type_c": "double",
-
-    # Precision of float printing (number of digits)
-    "precision": numpy.finfo(numpy.dtype("double")).precision,
 }
 
 


### PR DESCRIPTION
Add ability to suppress emission of ReturnAccumulate in scheduling. This is necessary for TSFC kernels where the output tensor is not zeroed on input.

Similarly, don't do `lvalue = lvalue + rvalue` when emitting `Return` nodes in loopy output (the accumulation should have happened in the `Accumulate` part of the pair, and again this presumes that the lvalue was zero on entry.