### PR TITLE
Direct serendipity

### DIFF
--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -203,16 +203,13 @@ class CoordinateMapping(PhysicalGeometry):
         config = {"point_set": point_set}
         config.update(self.config)
         context = PointSetContext(**config)
-        return map_expr_dag(context.translator, expr)
-
+        mapped = map_expr_dag(context.translator, expr)
+        indices = tuple(gem.Index() for _ in mapped.shape)
+        return gem.ComponentTensor(gem.Indexed(mapped, indices), point_set.indices + indices) 
+        
     def physical_vertices(self):
         vs = PointSet(self.interface.fiat_cell.vertices)
-        pvs = self.physical_points(vs)
-        return pvs
-        # print(pvs)
-        # i = gem.Index()
-        # j = pvs.free_indices
-        # return gem.ComponentTensor(gem.Indexed(pvs, (i,)), j + (i,))
+        return self.physical_points(vs)
 
 
 

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -147,12 +147,7 @@ class CoordinateMapping(PhysicalGeometry):
             expr = PositiveRestricted(expr)
         elif self.mt.restriction == '-':
             expr = NegativeRestricted(expr)
-# <<<<<<< HEAD
-#         expr = preprocess_expression(expr)
-#         config = {"point_set": ps}
-# =======
         config = {"point_set": PointSingleton(point)}
-# >>>>>>> origin/master
         config.update(self.config)
         context = PointSetContext(**config)
         expr = preprocess_expression(expr, complex_mode=context.complex_mode)

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -31,7 +31,7 @@ from gem.optimise import ffc_rounding
 from gem.unconcatenate import unconcatenate
 from gem.utils import cached_property
 
-from finat.physically_mapped import PhysicalGeometry, PhysicallyMappedElement
+from finat.physically_mapped import PhysicalGeometry, NeedsCoordinateMappingElement
 from finat.point_set import PointSet, PointSingleton
 from finat.quadrature import make_quadrature
 
@@ -207,7 +207,12 @@ class CoordinateMapping(PhysicalGeometry):
 
     def physical_vertices(self):
         vs = PointSet(self.interface.fiat_cell.vertices)
-        return self.physical_points(vs)
+        pvs = self.physical_points(vs)
+        return pvs
+        # print(pvs)
+        # i = gem.Index()
+        # j = pvs.free_indices
+        # return gem.ComponentTensor(gem.Indexed(pvs, (i,)), j + (i,))
 
 
 
@@ -216,7 +221,7 @@ def needs_coordinate_mapping(element):
     if element.family() == 'Real':
         return False
     else:
-        return isinstance(create_element(element), PhysicallyMappedElement)
+        return isinstance(create_element(element), NeedsCoordinateMappingElement)
 
 
 class PointSetContext(ContextBase):

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -23,7 +23,7 @@ from ufl.classes import (Argument, CellCoordinate, CellEdgeVectors,
 
 
 from FIAT.reference_element import make_affine_mapping
-from FIAT import ufc_simplex
+from FIAT.reference_element import UFCSimplex
 
 import gem
 from gem.node import traversal
@@ -154,13 +154,13 @@ class CoordinateMapping(PhysicalGeometry):
         return map_expr_dag(context.translator, expr)
 
     def reference_normals(self):
-        if not (isinstance(self.interface.fiat_cell, ufc_simplex) and
+        if not (isinstance(self.interface.fiat_cell, UFCSimplex) and
                 self.interface.fiat_cell.get_spatial_dimension() == 2):
             raise NotImplementedError("Only works for triangles for now")
         return gem.Literal(numpy.asarray([self.interface.fiat_cell.compute_normal(i) for i in range(3)]))
 
     def physical_tangents(self):
-        if not (isinstance(self.interface.fiat_cell, ufc_simplex) and
+        if not (isinstance(self.interface.fiat_cell, UFCSimplex) and
                 self.interface.fiat_cell.get_spatial_dimension() == 2):
             raise NotImplementedError("Only works for triangles for now")
 

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -139,7 +139,9 @@ class CoordinateMapping(PhysicalGeometry):
         return self.interface.cell_size(self.mt.restriction)
 
     def jacobian_at(self, point):
+        ps = PointSingleton(point)
         expr = Jacobian(self.mt.terminal.ufl_domain())
+        assert ps.expression.shape == (expr.ufl_domain().topological_dimension(), )
         if self.mt.restriction == '+':
             expr = PositiveRestricted(expr)
         elif self.mt.restriction == '-':

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -152,17 +152,14 @@ class CoordinateMapping(PhysicalGeometry):
         return map_expr_dag(context.translator, expr)
 
     def reference_normals(self):
-        if isinstance(self.interface.fiat_cell, FIAT.ufc_simplex) \
-           and self.interface.fiat_cell.get_spatial_dimension() == 2:
-            return gem.Literal(numpy.asarray([self.interface.fiat_cell.compute_normal(i) for i in range(3)]))
-        else:
+        if not (isinstance(self.interface.fiat_cell, ufc_simplex) and
+                self.interface.fiat_cell.get_spatial_dimension() == 2):
             raise NotImplementedError("Only works for triangles for now")
+        return gem.Literal(numpy.asarray([self.interface.fiat_cell.compute_normal(i) for i in range(3)]))
 
     def physical_tangents(self):
-        if isinstance(self.interface.fiat_cell, FIAT.ufc_simplex) \
-           and self.interface.fiat_cell.get_spatial_dimension() == 2:
-            return gem.Literal(numpy.asarray([self.interface.fiat_cell.compute_normal(i) for i in range(3)]))
-        else:
+        if not (isinstance(self.interface.fiat_cell, ufc_simplex) and
+                self.interface.fiat_cell.get_spatial_dimension() == 2):
             raise NotImplementedError("Only works for triangles for now")
 
         rts = [self.interface.fiat_cell.compute_tangents(1, f)[0] for f in range(3)]

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -71,7 +71,7 @@ supported_elements = {
     "Discontinuous Lagrange L2": finat.DiscontinuousLagrange,
     "Gauss-Legendre L2": finat.GaussLegendre,
     "DQ L2": None,
-    "Sphys": finat.DirectSerendipity,
+    "Sdirect": finat.DirectSerendipity,
 }
 """A :class:`.dict` mapping UFL element family names to their
 FInAT-equivalent constructors.  If the value is ``None``, the UFL

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -71,6 +71,7 @@ supported_elements = {
     "Discontinuous Lagrange L2": finat.DiscontinuousLagrange,
     "Gauss-Legendre L2": finat.GaussLegendre,
     "DQ L2": None,
+    "Sphys": finat.DirectSerendipity,
 }
 """A :class:`.dict` mapping UFL element family names to their
 FInAT-equivalent constructors.  If the value is ``None``, the UFL

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -71,7 +71,7 @@ supported_elements = {
     "Discontinuous Lagrange L2": finat.DiscontinuousLagrange,
     "Gauss-Legendre L2": finat.GaussLegendre,
     "DQ L2": None,
-    "Sdirect": finat.DirectSerendipity,
+    "Direct Serendipity": finat.DirectSerendipity,
 }
 """A :class:`.dict` mapping UFL element family names to their
 FInAT-equivalent constructors.  If the value is ``None``, the UFL


### PR DESCRIPTION
Adds support for elements that are defined directly in terms of physical cell geometry (bypassing a reference element/mapping).  Mainly, this involves enriching the interface for physical mapping callbacks.  It also updates the finat interface to include the newly-added direct serendipity family there.

This PR depends on FEniCS/ufl PR#32: https://github.com/FEniCS/ufl/pull/32
And supports the associated finat PR: https://github.com/FInAT/FInAT/pull/58