### PR TITLE
Ensure compile_ufl output has correct free indices

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -792,10 +792,6 @@ class Delta(Scalar, Terminal):
         assert isinstance(i, IndexBase)
         assert isinstance(j, IndexBase)
 
-        # \delta_{i,i} = 1
-        if i == j:
-            return one
-
         # Fixed indices
         if isinstance(i, int) and isinstance(j, int):
             return Literal(int(i == j))

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -102,6 +102,8 @@ def replace_indices_delta(node, self, subst):
     j = substitute.get(node.j, node.j)
     if i == node.i and j == node.j:
         return node
+    elif i == j:
+        return one
     else:
         return Delta(i, j)
 

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -377,7 +377,11 @@ def compile_expression_dual_evaluation(expression, to_element, *,
             quad_rule = QuadratureRule(point_set, to_element._weights)
             config["quadrature_rule"] = quad_rule
 
+        # evaluate expression at the points specified by point_set
         expr, = fem.compile_ufl(expression, **config, point_sum=False)
+        # the point set free indices should now be free indices of the compiled
+        # expression
+        assert set(point_set.indices) <= set(expr.free_indices)
         shape_indices = tuple(gem.Index() for _ in expr.shape)
         basis_indices = point_set.indices
         ir = gem.Indexed(expr, shape_indices)
@@ -395,7 +399,11 @@ def compile_expression_dual_evaluation(expression, to_element, *,
                 point_set = PointSet(pts)
                 config = kernel_cfg.copy()
                 config.update(point_set=point_set)
+                # evaluate expression at the points specified by point_set
                 expr, = fem.compile_ufl(expression, **config, point_sum=False)
+                # the point set free indices should now be free indices of the
+                # compiled expression
+                assert set(point_set.indices) <= set(expr.free_indices)
                 expr = gem.partial_indexed(expr, shape_indices)
                 expr_cache[pts] = expr, point_set
             weights = collections.defaultdict(list)


### PR DESCRIPTION
When an expression given to compile_ufl does not have points in the
input PointSet in its expression tree, the resulting gem expression has
missing free indices. This attempts to fix that.

Todo: 
 - [x] Fix failing tests