### PR TITLE
Update package names for installation CI on Python 3.8

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,5 +1,5 @@
 git+https://github.com/coneoproject/COFFEE.git#egg=coffee
-git+https://github.com/firedrakeproject/ufl.git#egg=ufl
+git+https://github.com/firedrakeproject/ufl.git#egg=fenics-ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
 git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -2,4 +2,4 @@ git+https://github.com/coneoproject/COFFEE.git#egg=coffee
 git+https://github.com/firedrakeproject/ufl.git#egg=fenics-ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
-git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy
+git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loo.py

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,5 +1,5 @@
 git+https://github.com/coneoproject/COFFEE.git#egg=coffee
 git+https://github.com/firedrakeproject/ufl.git#egg=fenics-ufl
-git+https://github.com/firedrakeproject/fiat.git#egg=fiat
+git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
 git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy


### PR DESCRIPTION
Attempt to fix travis failure to build on python 3.8:

```
Collecting ufl
  Cloning https://github.com/firedrakeproject/ufl.git to /tmp/pip-install-7o24cdg_/ufl_fbaa010190f9427f9e08fb25736a018e
  WARNING: Generating metadata for package ufl produced metadata for project name fenics-ufl. Fix your #egg=ufl fragments.
ERROR: Requested fenics-ufl from git+https://github.com/firedrakeproject/ufl.git#egg=ufl (from -r requirements-git.txt (line 2)) has different name in metadata: 'fenics-ufl'
The command "pip install -r requirements.txt" failed and exited with 1 during .
```

EDIT:

Also corrects for a similar problem with FIAT
```
Collecting fiat
  Cloning https://github.com/firedrakeproject/fiat.git to /tmp/pip-install-n537a5wq/fiat_1a6a243e61f749669754356ba34be67c
  WARNING: Generating metadata for package fiat produced metadata for project name fenics-fiat. Fix your #egg=fiat fragments.
ERROR: Requested fenics-fiat from git+https://github.com/firedrakeproject/fiat.git#egg=fiat (from -r requirements-git.txt (line 3)) has different name in metadata: 'fenics-fiat'
The command "pip install -r requirements.txt" failed and exited with 1 during .
```

EDIT2:

And loopy
```
Collecting loopy
  Cloning https://github.com/firedrakeproject/loopy.git (to revision firedrake) to /tmp/pip-install-rep6n8bj/loopy_9c0ad7e40feb48caa37471e983441f1c
  WARNING: Generating metadata for package loopy produced metadata for project name loo-py. Fix your #egg=loopy fragments.
ERROR: Requested loo-py from git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy (from -r requirements-git.txt (line 5)) has different name in metadata: 'loo.py'
The command "pip install -r requirements.txt" failed and exited with 1 during .
```