### PR TITLE
Support useful testing element from FInAT

### DIFF
--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -76,7 +76,7 @@ supported_elements = {
     "Gauss-Legendre L2": finat.GaussLegendre,
     "DQ L2": None,
     "Direct Serendipity": finat.DirectSerendipity,
-    "NewElement": finat.NewElement,
+    "C0 Modified": finat.C0Modified,
 }
 """A :class:`.dict` mapping UFL element family names to their
 FInAT-equivalent constructors.  If the value is ``None``, the UFL

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -76,6 +76,7 @@ supported_elements = {
     "Gauss-Legendre L2": finat.GaussLegendre,
     "DQ L2": None,
     "Direct Serendipity": finat.DirectSerendipity,
+    "NewElement": finat.NewElement,
 }
 """A :class:`.dict` mapping UFL element family names to their
 FInAT-equivalent constructors.  If the value is ``None``, the UFL


### PR DESCRIPTION
Adds support a new FInAT element with integral moment nodes and point evaluation nodes on an interval cell which is very useful for sanity checking. Name is very much up for negotiation!


Linked PRs:

https://github.com/FEniCS/fiat/pull/64
https://github.com/FEniCS/ufl/pull/47
https://github.com/FInAT/FInAT/pull/73