### PR TITLE
Translate WithMapping element

### DIFF
--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -253,6 +253,11 @@ def convert_hcurlelement(element, **kwargs):
     return finat.HCurlElement(finat_elem), deps
 
 
+@convert.register(ufl.WithMapping)
+def convert_withmapping(element, **kwargs):
+    return _create_element(element.wrapee, **kwargs)
+
+
 @convert.register(ufl.RestrictedElement)
 def convert_restrictedelement(element, **kwargs):
     finat_elem, deps = _create_element(element._element, **kwargs)


### PR DESCRIPTION
For example usage see Firedrake #2018 which also tests this feature (and currently passes).
After merging (plus the UFL companion), we'll update Firedrake #2018 so that it uses master UFL and TSFC.