### PR TITLE
fem: CoordinateMapping needs to push restrictions to terminals

### DIFF
--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -129,6 +129,17 @@ class CoordinateMapping(PhysicalGeometry):
         self.mt = mt
         self.interface = interface
 
+    def preprocess(self, expr, context):
+        """Preprocess a UFL expression for translation.
+
+        :arg expr: A UFL expression
+        :arg context: The translation context.
+        :returns: A new UFL expression
+        """
+        ifacet = self.interface.integral_type.startswith("interior_facet")
+        return preprocess_expression(expr, complex_mode=context.complex_mode,
+                                     do_apply_restrictions=ifacet)
+
     @property
     def config(self):
         config = {name: getattr(self.interface, name)
@@ -150,7 +161,7 @@ class CoordinateMapping(PhysicalGeometry):
         config = {"point_set": PointSingleton(point)}
         config.update(self.config)
         context = PointSetContext(**config)
-        expr = preprocess_expression(expr, complex_mode=context.complex_mode)
+        expr = self.preprocess(expr, context)
         return map_expr_dag(context.translator, expr)
 
     def detJ_at(self, point):
@@ -159,11 +170,10 @@ class CoordinateMapping(PhysicalGeometry):
             expr = PositiveRestricted(expr)
         elif self.mt.restriction == '-':
             expr = NegativeRestricted(expr)
-        expr = preprocess_expression(expr)
-
         config = {"point_set": PointSingleton(point)}
         config.update(self.config)
         context = PointSetContext(**config)
+        expr = self.preprocess(expr, context)
         return map_expr_dag(context.translator, expr)
 
     def reference_normals(self):
@@ -204,7 +214,7 @@ class CoordinateMapping(PhysicalGeometry):
         config = {"point_set": PointSingleton([1/3, 1/3])}
         config.update(self.config)
         context = PointSetContext(**config)
-        expr = preprocess_expression(expr, complex_mode=context.complex_mode)
+        expr = self.preprocess(expr, context)
         return map_expr_dag(context.translator, expr)
 
     def physical_points(self, point_set, entity=None):
@@ -220,13 +230,13 @@ class CoordinateMapping(PhysicalGeometry):
             expr = PositiveRestricted(expr)
         elif self.mt.restriction == '-':
             expr = NegativeRestricted(expr)
-        expr = preprocess_expression(expr)
         config = {"point_set": point_set}
         config.update(self.config)
         if entity is not None:
             config.update({name: getattr(self.interface, name)
                            for name in ["integration_dim", "entity_ids"]})
         context = PointSetContext(**config)
+        expr = self.preprocess(expr, context)
         mapped = map_expr_dag(context.translator, expr)
         indices = tuple(gem.Index() for _ in mapped.shape)
         return gem.ComponentTensor(gem.Indexed(mapped, indices), point_set.indices + indices)

--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -13,6 +13,7 @@ from ufl.algorithms.apply_function_pullbacks import apply_function_pullbacks
 from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
 from ufl.algorithms.apply_derivatives import apply_derivatives
 from ufl.algorithms.apply_geometry_lowering import apply_geometry_lowering
+from ufl.algorithms.apply_restrictions import apply_restrictions
 from ufl.algorithms.comparison_checker import do_comparison_check
 from ufl.algorithms.remove_complex_nodes import remove_complex_nodes
 from ufl.corealg.map_dag import map_expr_dag
@@ -102,8 +103,12 @@ def entity_avg(integrand, measure, argument_multiindices):
     return integrand, degree, argument_multiindices
 
 
-def preprocess_expression(expression, complex_mode=False):
+def preprocess_expression(expression, complex_mode=False,
+                          do_apply_restrictions=False):
     """Imitates the compute_form_data processing pipeline.
+
+    :arg complex_mode: Are we in complex UFL mode?
+    :arg do_apply_restrictions: Propogate restrictions to terminals?
 
     Useful, for example, to preprocess non-scalar expressions, which
     are not and cannot be forms.
@@ -121,6 +126,8 @@ def preprocess_expression(expression, complex_mode=False):
     expression = apply_derivatives(expression)
     if not complex_mode:
         expression = remove_complex_nodes(expression)
+    if do_apply_restrictions:
+        expression = apply_restrictions(expression)
     return expression
 
 


### PR DESCRIPTION
When preprocessing restricted expressions inside the CoordinateMapping
callbacks we need to push restrictions to terminals so the later parts
of the pipeline work. Fixes FInAT/FInAT#77.