### PR TITLE
ComponentTensor: allow zero extent shape indices

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -651,7 +651,7 @@ class ComponentTensor(Node):
 
         # Collect shape
         shape = tuple(index.extent for index in multiindex)
-        assert all(shape)
+        assert all(s >= 0 for s in shape)
 
         # Zero folding
         if isinstance(expression, Zero):


### PR DESCRIPTION
The assertion which is updated did not account for indices having zero
extent which can occur (e.g. when dealing with 0D quantities like
vertices)

See also https://github.com/FInAT/FInAT/issues/78 which this resolves.