### PR TITLE
Target loopy main in requirements-git.txt

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -2,4 +2,4 @@ git+https://github.com/coneoproject/COFFEE.git#egg=coffee
 git+https://github.com/firedrakeproject/ufl.git#egg=fenics-ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat
 git+https://github.com/FInAT/FInAT.git#egg=finat
-git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy
+git+https://github.com/firedrakeproject/loopy.git#egg=loopy


### PR DESCRIPTION
main is now the default branch for firedrake so we should test against
that rather than the retired firedrake branch.