### PR TITLE
optimise: option to ignore indices in sum factorisation

### DIFF
--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -481,12 +481,17 @@ def traverse_sum(expression, stop_at=None):
     return result
 
 
-def contraction(expression):
+def contraction(expression, ignore=None):
     """Optimise the contractions of the tensor product at the root of
     the expression, including:
 
     - IndexSum-Delta cancellation
     - Sum factorisation
+
+    :arg ignore: Optional set of indices to ignore when applying sum
+        factorisation (otherwise all summation indices will be
+        considered). Use this if your expression has many contraction
+        indices.
 
     This routine was designed with finite element coefficient
     evaluation in mind.
@@ -498,7 +503,12 @@ def contraction(expression):
     def rebuild(expression):
         sum_indices, factors = delta_elimination(*traverse_product(expression))
         factors = remove_componenttensors(factors)
-        return sum_factorise(sum_indices, factors)
+        if ignore is not None:
+            extra = tuple(i for i in sum_indices if i in ignore)
+            to_factor = tuple(i for i in sum_indices if i not in ignore)
+            return IndexSum(sum_factorise(to_factor, factors), extra)
+        else:
+            return sum_factorise(sum_indices, factors)
 
     # Sometimes the value shape is composed as a ListTensor, which
     # could get in the way of decomposing factors.  In particular,


### PR DESCRIPTION
For optimisation of dual evaluation, we want to sum factorise a
contraction, but know some sets of indices we just need to treat with
delta elimination. Allow caller to exclude these indices from the
factorisation routines to avoid N! behaviour for large N.