### PR TITLE
Add fdm variant for TP elements

### DIFF
--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -143,7 +143,9 @@ def convert_finiteelement(element, **kwargs):
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLobattoLegendre
         elif kind == 'fdm' and element.cell().cellname() == 'interval':
-            lmbda = finat.FDMElement
+            lmbda = finat.FDMLagrange
+        elif kind == 'fdmhermite' and element.cell().cellname() == 'interval':
+            lmbda = finat.FDMHermite
         elif kind in ['mgd', 'feec', 'qb', 'mse']:
             degree = element.degree()
             shift_axes = kwargs["shift_axes"]
@@ -161,7 +163,7 @@ def convert_finiteelement(element, **kwargs):
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLegendre
         elif kind == 'fdm' and element.cell().cellname() == 'interval':
-            lmbda = lambda c, d: finat.FDMElement(c, d, formdegree=1)
+            lmbda = lambda *args: finat.DiscontinuousElement(finat.FDMLagrange(*args))
         elif kind in ['mgd', 'feec', 'qb', 'mse']:
             degree = element.degree()
             shift_axes = kwargs["shift_axes"]

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -140,10 +140,10 @@ def convert_finiteelement(element, **kwargs):
     if element.family() == "Lagrange":
         if kind == 'equispaced':
             lmbda = finat.Lagrange
-        elif kind == 'fdm' and element.cell().cellname() == 'interval':
-            lmbda = finat.FDMElement
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLobattoLegendre
+        elif kind == 'fdm' and element.cell().cellname() == 'interval':
+            lmbda = finat.FDMElement
         elif kind in ['mgd', 'feec', 'qb', 'mse']:
             degree = element.degree()
             shift_axes = kwargs["shift_axes"]

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -140,6 +140,8 @@ def convert_finiteelement(element, **kwargs):
     if element.family() == "Lagrange":
         if kind == 'equispaced':
             lmbda = finat.Lagrange
+        elif kind == 'fdm' and element.cell().cellname() == 'interval':
+            lmbda = finat.FDMElement
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLobattoLegendre
         elif kind in ['mgd', 'feec', 'qb', 'mse']:
@@ -158,6 +160,8 @@ def convert_finiteelement(element, **kwargs):
             lmbda = finat.DiscontinuousLagrange
         elif kind == 'spectral' and element.cell().cellname() == 'interval':
             lmbda = finat.GaussLegendre
+        elif kind == 'fdm' and element.cell().cellname() == 'interval':
+            lmbda = lambda c, d: finat.FDMElement(c, d, formdegree=1)
         elif kind in ['mgd', 'feec', 'qb', 'mse']:
             degree = element.degree()
             shift_axes = kwargs["shift_axes"]


### PR DESCRIPTION
This enables the construction of Q, DQ, RTCF, RTCE, NCF, NCE spaces using tensor products of FDM shape functions.
Depends on [FIAT#26](https://github.com/firedrakeproject/fiat/pull/26) and [FInAT#100](https://github.com/FInAT/FInAT/pull/100).