### PR TITLE
Remove deprecated argument to get_op_map

### DIFF
--- a/tests/test_impero_loopy_flop_counts.py
+++ b/tests/test_impero_loopy_flop_counts.py
@@ -22,7 +22,6 @@ def count_loopy_flops(kernel):
     )
     op_map = loopy.get_op_map(program
                               .with_entrypoints(kernel.name),
-                              numpy_types=None,
                               subgroup_size=1)
     return op_map.filter_by(name=['add', 'sub', 'mul', 'div',
                                   'func:abs'],


### PR DESCRIPTION
CI is failing because of [this loopy commit](https://github.com/firedrakeproject/loopy/commit/752d758c61faa980b5841d92b7d5acbe4c3f8135). Very simple fix.