### PR TITLE
Remove coefficients from ExpressionKernel

### DIFF
--- a/tests/test_dual_evaluation.py
+++ b/tests/test_dual_evaluation.py
@@ -12,7 +12,7 @@ def test_ufl_only_simple():
     W = V
     to_element = create_element(W.ufl_element())
     kernel = compile_expression_dual_evaluation(expr, to_element, W.ufl_element())
-    assert kernel.first_coefficient_fake_coords is False
+    assert kernel.needs_external_coords is False
 
 
 def test_ufl_only_spatialcoordinate():
@@ -23,7 +23,7 @@ def test_ufl_only_spatialcoordinate():
     W = V
     to_element = create_element(W.ufl_element())
     kernel = compile_expression_dual_evaluation(expr, to_element, W.ufl_element())
-    assert kernel.first_coefficient_fake_coords is True
+    assert kernel.needs_external_coords is True
 
 
 def test_ufl_only_from_contravariant_piola():
@@ -34,7 +34,7 @@ def test_ufl_only_from_contravariant_piola():
     W = ufl.FunctionSpace(mesh, ufl.FiniteElement("P", ufl.triangle, 2))
     to_element = create_element(W.ufl_element())
     kernel = compile_expression_dual_evaluation(expr, to_element, W.ufl_element())
-    assert kernel.first_coefficient_fake_coords is True
+    assert kernel.needs_external_coords is True
 
 
 def test_ufl_only_to_contravariant_piola():
@@ -45,7 +45,7 @@ def test_ufl_only_to_contravariant_piola():
     W = ufl.FunctionSpace(mesh, ufl.FiniteElement("RT", ufl.triangle, 1))
     to_element = create_element(W.ufl_element())
     kernel = compile_expression_dual_evaluation(expr, to_element, W.ufl_element())
-    assert kernel.first_coefficient_fake_coords is True
+    assert kernel.needs_external_coords is True
 
 
 def test_ufl_only_shape_mismatch():

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -183,6 +183,9 @@ def compile_expression_dual_evaluation(expression, to_element, ufl_element, *,
 
     if isinstance(to_element, (PhysicallyMappedElement, DirectlyDefinedElement)):
         raise NotImplementedError("Don't know how to interpolate onto zany spaces, sorry")
+
+    orig_expression = expression
+
     # Map into reference space
     expression = apply_mapping(expression, ufl_element, domain)
 
@@ -205,9 +208,13 @@ def compile_expression_dual_evaluation(expression, to_element, ufl_element, *,
         domain = expression.ufl_domain()
     assert domain is not None
 
-    # Collect required coefficients
-    first_coefficient_fake_coords = False
+    # Collect required coefficients and determine numbering
     coefficients = extract_coefficients(expression)
+    orig_coefficients = extract_coefficients(orig_expression)
+    coefficient_numbers = tuple(orig_coefficients.index(c) for c in coefficients)
+    builder.set_coefficient_numbers(coefficient_numbers)
+
+    first_coefficient_fake_coords = False
     if has_type(expression, GeometricQuantity) or any(fem.needs_coordinate_mapping(c.ufl_element()) for c in coefficients):
         # Create a fake coordinate coefficient for a domain.
         coords_coefficient = ufl.Coefficient(ufl.FunctionSpace(domain, domain.ufl_coordinate_element()))

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -214,14 +214,14 @@ def compile_expression_dual_evaluation(expression, to_element, ufl_element, *,
     coefficient_numbers = tuple(orig_coefficients.index(c) for c in coefficients)
     builder.set_coefficient_numbers(coefficient_numbers)
 
-    first_coefficient_fake_coords = False
+    needs_external_coords = False
     if has_type(expression, GeometricQuantity) or any(fem.needs_coordinate_mapping(c.ufl_element()) for c in coefficients):
         # Create a fake coordinate coefficient for a domain.
         coords_coefficient = ufl.Coefficient(ufl.FunctionSpace(domain, domain.ufl_coordinate_element()))
         builder.domain_coordinate[domain] = coords_coefficient
         builder.set_cell_sizes(domain)
         coefficients = [coords_coefficient] + coefficients
-        first_coefficient_fake_coords = True
+        needs_external_coords = True
     builder.set_coefficients(coefficients)
 
     # Split mixed coefficients
@@ -264,7 +264,7 @@ def compile_expression_dual_evaluation(expression, to_element, ufl_element, *,
     builder.register_requirements([evaluation])
     builder.set_output(return_var)
     # Build kernel tuple
-    return builder.construct_kernel(impero_c, index_names, first_coefficient_fake_coords)
+    return builder.construct_kernel(impero_c, index_names, needs_external_coords)
 
 
 class DualEvaluationCallable(object):

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -19,8 +19,11 @@ from tsfc.loopy import generate as generate_loopy
 
 
 # Expression kernel description type
-ExpressionKernel = namedtuple('ExpressionKernel', ['ast', 'oriented', 'needs_cell_sizes', 'coefficients',
-                                                   'first_coefficient_fake_coords', 'tabulations', 'name', 'arguments', 'flop_count'])
+ExpressionKernel = namedtuple('ExpressionKernel', ['ast', 'oriented', 'needs_cell_sizes',
+                                                   'coefficient_numbers',
+                                                   'first_coefficient_fake_coords',
+                                                   'tabulations', 'name', 'arguments',
+                                                   'flop_count'])
 
 
 def make_builder(*args, **kwargs):
@@ -144,23 +147,28 @@ class ExpressionKernelBuilder(KernelBuilderBase):
 
         :arg coefficients: UFL coefficients from Firedrake
         """
-        self.coefficients = []  # Firedrake coefficients for calling the kernel
         self.coefficient_split = {}
         self.kernel_args = []
 
         for i, coefficient in enumerate(coefficients):
             if type(coefficient.ufl_element()) == ufl_MixedElement:
                 subcoeffs = coefficient.split()  # Firedrake-specific
-                self.coefficients.extend(subcoeffs)
                 self.coefficient_split[coefficient] = subcoeffs
                 coeff_loopy_args = [self._coefficient(subcoeff, f"w_{i}_{j}")
                                     for j, subcoeff in enumerate(subcoeffs)]
                 self.kernel_args += [kernel_args.CoefficientKernelArg(a)
                                      for a in coeff_loopy_args]
             else:
-                self.coefficients.append(coefficient)
                 coeff_loopy_arg = self._coefficient(coefficient, f"w_{i}")
                 self.kernel_args.append(kernel_args.CoefficientKernelArg(coeff_loopy_arg))
+
+    def set_coefficient_numbers(self, coefficient_numbers):
+        """Store the coefficient indices of the original form.
+
+        :arg coefficient_numbers: Iterable of indices describing which coefficients
+            from the input expression need to be passed in to the kernel.
+        """
+        self.coefficient_numbers = coefficient_numbers
 
     def register_requirements(self, ir):
         """Inspect what is referenced by the IR that needs to be
@@ -197,7 +205,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         loopy_kernel = generate_loopy(impero_c, loopy_args, self.scalar_type,
                                       name, index_names)
         return ExpressionKernel(loopy_kernel, self.oriented, self.cell_sizes,
-                                self.coefficients, first_coefficient_fake_coords,
+                                self.coefficient_numbers, first_coefficient_fake_coords,
                                 self.tabulations, name, args, count_flops(impero_c))
 
 

--- a/tsfc/kernel_interface/firedrake_loopy.py
+++ b/tsfc/kernel_interface/firedrake_loopy.py
@@ -21,7 +21,7 @@ from tsfc.loopy import generate as generate_loopy
 # Expression kernel description type
 ExpressionKernel = namedtuple('ExpressionKernel', ['ast', 'oriented', 'needs_cell_sizes',
                                                    'coefficient_numbers',
-                                                   'first_coefficient_fake_coords',
+                                                   'needs_external_coords',
                                                    'tabulations', 'name', 'arguments',
                                                    'flop_count'])
 
@@ -180,13 +180,13 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         loopy_arg = lp.GlobalArg(o.name, dtype=self.scalar_type, shape=o.shape)
         self.output_arg = kernel_args.OutputKernelArg(loopy_arg)
 
-    def construct_kernel(self, impero_c, index_names, first_coefficient_fake_coords):
+    def construct_kernel(self, impero_c, index_names, needs_external_coords):
         """Constructs an :class:`ExpressionKernel`.
 
         :arg impero_c: gem.ImperoC object that represents the kernel
         :arg index_names: pre-assigned index names
-        :arg first_coefficient_fake_coords: If true, the kernel's first
-            coefficient is a constructed UFL coordinate field
+        :arg needs_external_coords: If ``True``, the first argument to
+            the kernel is an externally provided coordinate field.
         :returns: :class:`ExpressionKernel` object
         """
         args = [self.output_arg]
@@ -205,7 +205,7 @@ class ExpressionKernelBuilder(KernelBuilderBase):
         loopy_kernel = generate_loopy(impero_c, loopy_args, self.scalar_type,
                                       name, index_names)
         return ExpressionKernel(loopy_kernel, self.oriented, self.cell_sizes,
-                                self.coefficient_numbers, first_coefficient_fake_coords,
+                                self.coefficient_numbers, needs_external_coords,
                                 self.tabulations, name, args, count_flops(impero_c))
 
 


### PR DESCRIPTION
This should be useful to do because UFL coefficients are large data structures which until now have inhibited caching of the generated `ExpressionKernel`.