### PR TITLE
driver: raise NotImplementedError for diagonal + interior_facet

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -99,6 +99,8 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, co
             interface = firedrake_interface_loopy.KernelBuilder
     scalar_type = parameters["scalar_type"]
     integral_type = integral_data.integral_type
+    if integral_type.startswith("interior_facet") and diagonal:
+        raise NotImplementedError("Sorry, we can't assemble the diagonal of a form for interior facet integrals")
     mesh = integral_data.domain
     arguments = form_data.preprocessed_form.arguments()
     kernel_name = "%s_%s_integral_%s" % (prefix, integral_type, integral_data.subdomain_id)


### PR DESCRIPTION
Fixes firedrakeproject/firedrake#2300 by making the error loud rather than quiet.