### PR TITLE
Maybe fix issue 274

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -211,11 +211,7 @@ class Literal(Constant):
 
     def __new__(cls, array):
         array = asarray(array)
-        if (array == 0).all():
-            # All zeros, make symbolic zero
-            return Zero(array.shape)
-        else:
-            return super(Literal, cls).__new__(cls)
+        return super(Literal, cls).__new__(cls)
 
     def __init__(self, array):
         array = asarray(array)

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -548,6 +548,8 @@ class Indexed(Scalar):
             assert isinstance(index, IndexBase)
             if isinstance(index, Index):
                 index.set_extent(extent)
+            elif isinstance(index, int) and not (0 <= index < extent):
+                raise IndexError("Invalid literal index")
 
         # Empty multiindex
         if not multiindex:

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -155,6 +155,35 @@ def remove_componenttensors(expressions):
     return [mapper(expression, ()) for expression in expressions]
 
 
+@singledispatch
+def _constant_fold_zero(node, self):
+    raise AssertionError("cannot handle type %s" % type(node))
+
+
+_constant_fold_zero.register(Node)(reuse_if_untouched)
+
+
+@_constant_fold_zero.register(Literal)
+def _constant_fold_zero_literal(node, self):
+    if (node.array == 0).all():
+        # All zeros, make symbolic zero
+        return Zero(node.shape)
+    else:
+        return node
+
+
+def constant_fold_zero(exprs):
+    """Produce symbolic zeros from Literals
+
+    :arg exprs: An iterable of gem expressions.
+    :returns: A list of gem expressions where any Literal containing
+        only zeros is replaced by symbolic Zero of the appropriate
+        shape.
+    """
+    mapper = Memoizer(_constant_fold_zero)
+    return [mapper(e) for e in exprs]
+
+
 def _select_expression(expressions, index):
     """Helper function to select an expression from a list of
     expressions with an index.  This function expect sanitised input,

--- a/tests/test_tsfc_274.py
+++ b/tests/test_tsfc_274.py
@@ -1,0 +1,40 @@
+import gem
+import numpy
+from finat.point_set import PointSet
+from gem.interpreter import evaluate
+from tsfc.finatinterface import create_element
+from ufl import FiniteElement, RestrictedElement, quadrilateral
+
+
+def test_issue_274():
+    # See https://github.com/firedrakeproject/tsfc/issues/274
+    ufl_element = RestrictedElement(
+        FiniteElement("Q", quadrilateral, 2), restriction_domain="facet"
+    )
+    ps = PointSet([[0.5]])
+    finat_element = create_element(ufl_element)
+    evaluations = []
+    for eid in range(4):
+        (val,) = finat_element.basis_evaluation(0, ps, (1, eid)).values()
+        evaluations.append(val)
+
+    i = gem.Index()
+    j = gem.Index()
+    (expr,) = evaluate(
+        [
+            gem.ComponentTensor(
+                gem.Indexed(gem.select_expression(evaluations, i), (j,)),
+                (*ps.indices, i, j),
+            )
+        ]
+    )
+
+    (expect,) = evaluate(
+        [
+            gem.ComponentTensor(
+                gem.Indexed(gem.ListTensor(evaluations), (i, j)), (*ps.indices, i, j)
+            )
+        ]
+    )
+
+    assert numpy.allclose(expr.arr, expect.arr)

--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -27,7 +27,7 @@ from FIAT.reference_element import UFCSimplex
 
 import gem
 from gem.node import traversal
-from gem.optimise import ffc_rounding
+from gem.optimise import ffc_rounding, constant_fold_zero
 from gem.unconcatenate import unconcatenate
 from gem.utils import cached_property
 
@@ -603,6 +603,7 @@ def fiat_to_ufl(fiat_dict, order):
         tensor = gem.Indexed(gem.ListTensor(tensor), delta)
     else:
         tensor = tensor[()]
+    tensor, = constant_fold_zero([tensor])
     return gem.ComponentTensor(tensor, sigma + delta)
 
 
@@ -718,4 +719,4 @@ def compile_ufl(expression, context, interior_facet=False, point_sum=False):
     result = map_expr_dags(context.translator, expressions)
     if point_sum:
         result = [gem.index_sum(expr, context.point_indices) for expr in result]
-    return result
+    return constant_fold_zero(result)


### PR DESCRIPTION
An attempt to address #274. Rather than eagerly producing a symbolic `Zero` from a `Literal(array_of_zeros)` do it late as a separate pass.

I don't know if this has negative consequences. I _think_ it doesn't because the way everything was being glued together previously these literal zeros were being pushed into a `Literal` with some non-zero elements anyway.

Needs tested against Firedrake:
- https://github.com/firedrakeproject/firedrake/pull/2406