### PR TITLE
Remove python 3.6 from test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [3.6, 3.7, 3.8, 3.9]
+        python_version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python


### PR DESCRIPTION
Python 3.6-based tests are breaking trying to merge in a new feature (trimmed serendipity), and we're not supporting it anymore anyway...