### PR TITLE
Add insn_count_subgroups_upper_bound warning in TSFC Loo.py kernels

### DIFF
--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -240,7 +240,8 @@ def generate(impero_c, args, scalar_type, kernel_name="loopy_kernel", index_name
 
     # Create loopy kernel
     knl = lp.make_function(domains, instructions, data, name=kernel_name, target=target,
-                           seq_dependencies=True, silenced_warnings=["summing_if_branches_ops"],
+                           seq_dependencies=True, silenced_warnings=["summing_if_branches_ops",
+                                                                     "insn_count_subgroups_upper_bound"],
                            lang_version=(2018, 2), preambles=preamble)
 
     # Prevent loopy interchange by loopy


### PR DESCRIPTION
Shutting up the Loo.py warnings for the FLOP counting in this PR https://github.com/OP2/PyOP2/pull/668