### PR TITLE
Fix interpolation for Arguments of zany spaces

### DIFF
--- a/tests/test_dual_evaluation.py
+++ b/tests/test_dual_evaluation.py
@@ -59,3 +59,13 @@ def test_ufl_only_shape_mismatch():
     assert to_element.value_shape == (2,)
     with pytest.raises(ValueError):
         compile_expression_dual_evaluation(expr, to_element, W.ufl_element())
+
+
+def test_interpolate_zany_argument():
+    mesh = ufl.Mesh(ufl.VectorElement("P", ufl.triangle, 2))
+    V = ufl.FunctionSpace(mesh, ufl.FiniteElement("P", ufl.triangle, 1))
+    Q = ufl.FunctionSpace(mesh, ufl.FiniteElement("Argyris", ufl.triangle, 5))
+    expr = ufl.TestFunction(Q)
+    to_element = create_element(V.ufl_element())
+    kernel = compile_expression_dual_evaluation(expr, to_element, V.ufl_element())
+    assert kernel.needs_external_coords

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -222,7 +222,10 @@ def compile_expression_dual_evaluation(expression, to_element, ufl_element, *,
     builder.set_coefficient_numbers(coefficient_numbers)
 
     needs_external_coords = False
-    if has_type(expression, GeometricQuantity) or any(fem.needs_coordinate_mapping(c.ufl_element()) for c in coefficients):
+    if has_type(expression, GeometricQuantity) or any(
+        fem.needs_coordinate_mapping(c.ufl_element())
+        for c in chain(coefficients, arguments)
+    ):
         # Create a fake coordinate coefficient for a domain.
         coords_coefficient = ufl.Coefficient(ufl.FunctionSpace(domain, domain.ufl_coordinate_element()))
         builder.domain_coordinate[domain] = coords_coefficient


### PR DESCRIPTION
Previously we only checked if any coefficients in the source expression needed a coordinate mapping, but we should also check if any arguments do.