### PR TITLE
Adapt to UFL changes in subdomain_id

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -115,7 +115,10 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, *,
         raise NotImplementedError("Sorry, we can't assemble the diagonal of a form for interior facet integrals")
     mesh = integral_data.domain
     arguments = form_data.preprocessed_form.arguments()
-    kernel_name = "%s_%s_integral_%s" % (prefix, integral_type, integral_data.subdomain_id)
+    kernel_name = (
+        f"{prefix}_{integral_type}_integral_"
+        f"{'_'.join([str(sid) for sid in integral_data.subdomain_id])}"
+    )
     # Handle negative subdomain_id
     kernel_name = kernel_name.replace("-", "_")
     # Dict mapping domains to index in original_form.ufl_domains()


### PR DESCRIPTION
See https://github.com/FEniCS/ufl/pull/92.

Needs to land before a corresponding Firedrake PR.