### PR TITLE
Simple fix for pyop3

### DIFF
--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -246,9 +246,17 @@ def generate(impero_c, args, scalar_type, kernel_name="loopy_kernel", index_name
     domains = create_domains(ctx.index_extent.items())
 
     # Create loopy kernel
-    knl = lp.make_kernel(domains, instructions, data, name=kernel_name, target=target,
-                         seq_dependencies=True, silenced_warnings=["summing_if_branches_ops"],
-                         lang_version=(2018, 2), preambles=preamble)
+    knl = lp.make_kernel(
+        domains,
+        instructions,
+        data,
+        name=kernel_name,
+        target=target,
+        seq_dependencies=True,
+        silenced_warnings=["summing_if_branches_ops"],
+        lang_version=(2018, 2),
+        preambles=preamble
+    )
 
     # Prevent loopy interchange by loopy
     knl = lp.prioritize_loops(knl, ",".join(ctx.index_extent.keys()))

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -246,9 +246,9 @@ def generate(impero_c, args, scalar_type, kernel_name="loopy_kernel", index_name
     domains = create_domains(ctx.index_extent.items())
 
     # Create loopy kernel
-    knl = lp.make_function(domains, instructions, data, name=kernel_name, target=target,
-                           seq_dependencies=True, silenced_warnings=["summing_if_branches_ops"],
-                           lang_version=(2018, 2), preambles=preamble)
+    knl = lp.make_kernel(domains, instructions, data, name=kernel_name, target=target,
+                         seq_dependencies=True, silenced_warnings=["summing_if_branches_ops"],
+                         lang_version=(2018, 2), preambles=preamble)
 
     # Prevent loopy interchange by loopy
     knl = lp.prioritize_loops(knl, ",".join(ctx.index_extent.keys()))


### PR DESCRIPTION
This small API change lets me use `default_entrypoint` later on when I am generating code (https://github.com/inducer/loopy/blob/db136129dc53b48a63cc5e5eb597a77540093132/loopy/kernel/creation.py#L2618).

Firedrake CI run: https://github.com/firedrakeproject/firedrake/pull/3811

I really doubt this will cause any issues but I cannot be sure.