### PR TITLE
Allow for string quadrature schemes

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,4 +1,4 @@
 git+https://github.com/firedrakeproject/ufl.git#egg=fenics-ufl
 git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat
-git+https://github.com/FInAT/FInAT.git#egg=finat
+git+https://github.com/FInAT/FInAT.git@pbrubeck/feature/gll-scheme
 git+https://github.com/firedrakeproject/loopy.git#egg=loopy

--- a/tests/test_underintegration.py
+++ b/tests/test_underintegration.py
@@ -13,7 +13,7 @@ def mass_cg(cell, degree):
     V = FunctionSpace(m, FiniteElement('Q', cell, degree, variant='spectral'))
     u = TrialFunction(V)
     v = TestFunction(V)
-    return u*v*dx(scheme="gll", degree=2*degree)
+    return u*v*dx(scheme="gll", degree=2*degree-1)
 
 
 def mass_dg(cell, degree):
@@ -29,7 +29,7 @@ def laplace(cell, degree):
     V = FunctionSpace(m, FiniteElement('Q', cell, degree, variant='spectral'))
     u = TrialFunction(V)
     v = TestFunction(V)
-    return dot(grad(u), grad(v))*dx(scheme="gll", degree=2*degree)
+    return dot(grad(u), grad(v))*dx(scheme="gll", degree=2*degree-1)
 
 
 def count_flops(form):

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -308,7 +308,8 @@ def set_quad_rule(params, cell, integral_type, functions):
                            "than tenfold greater than any "
                            "argument/coefficient degree (max %s)",
                            quadrature_degree, max_degree(function_degrees))
-    if params.get("quadrature_rule") == "default":
+    scheme = params.get("quadrature_rule")
+    if isinstance(scheme, str):
         del params["quadrature_rule"]
     try:
         quad_rule = params["quadrature_rule"]
@@ -316,7 +317,7 @@ def set_quad_rule(params, cell, integral_type, functions):
         fiat_cell = as_fiat_cell(cell)
         integration_dim, _ = lower_integral_type(fiat_cell, integral_type)
         integration_cell = fiat_cell.construct_subelement(integration_dim)
-        quad_rule = make_quadrature(integration_cell, quadrature_degree)
+        quad_rule = make_quadrature(integration_cell, quadrature_degree, scheme or "default")
         params["quadrature_rule"] = quad_rule
 
     if not isinstance(quad_rule, AbstractQuadratureRule):


### PR DESCRIPTION
This PR enables a more user-friendly interface to specify the quadrature scheme.

Users can now specify the quadraure scheme via `dx(scheme=scheme)`, and can choose any scheme that is already supported by `FIAT.create_quadrature`, including "default" (GL on TP cells / XG on simplices), "canonical" (GL on TP cells / Stroud on simplices), "KMV" (for limited quadrature degree and only on simplices), or "GLL" (only on TP cells).

Depends on https://github.com/FInAT/FInAT/pull/122