### PR TITLE
Rckirby/ps

### DIFF
--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -54,6 +54,7 @@ supported_elements = {
     "Argyris": finat.Argyris,
     "Hsieh-Clough-Tocher": finat.HsiehCloughTocher,
     "QuadraticPowellSabin6": finat.QuadraticPowellSabin6,
+    "QuadraticPowellSabin12": finat.QuadraticPowellSabin12,
     "Reduced-Hsieh-Clough-Tocher": finat.ReducedHsiehCloughTocher,
     "Mardal-Tai-Winther": finat.MardalTaiWinther,
     "Morley": finat.Morley,

--- a/tsfc/finatinterface.py
+++ b/tsfc/finatinterface.py
@@ -53,6 +53,7 @@ supported_elements = {
     "Kong-Mulder-Veldhuizen": finat.KongMulderVeldhuizen,
     "Argyris": finat.Argyris,
     "Hsieh-Clough-Tocher": finat.HsiehCloughTocher,
+    "QuadraticPowellSabin6": finat.QuadraticPowellSabin6,
     "Reduced-Hsieh-Clough-Tocher": finat.ReducedHsiehCloughTocher,
     "Mardal-Tai-Winther": finat.MardalTaiWinther,
     "Morley": finat.Morley,


### PR DESCRIPTION
Add support for Powell-Sabin triangular macroelements.
Requires 

- https://github.com/firedrakeproject/fiat/pull/78
- https://github.com/FInAT/FInAT/pull/132
