### PR TITLE
generalise VariableIndex and FlexiblyIndexed

### DIFF
--- a/gem/scheduling.py
+++ b/gem/scheduling.py
@@ -3,6 +3,7 @@ forming an ordered list of Impero terminals."""
 
 import collections
 import functools
+import itertools
 
 from gem import gem, impero
 from gem.node import collect_refcount
@@ -116,8 +117,12 @@ def handle(ops, push, decref, node):
     elif isinstance(node, gem.Zero):  # should rarely happen
         assert not node.shape
     elif isinstance(node, (gem.Indexed, gem.FlexiblyIndexed)):
-        # Indexing always inlined
-        decref(node.children[0])
+        if node.indirect_children:
+            # Do not inline;
+            # Index expression can be involved if it contains VariableIndex.
+            ops.append(impero.Evaluate(node))
+        for child in itertools.chain(node.children, node.indirect_children):
+            decref(child)
     elif isinstance(node, gem.IndexSum):
         ops.append(impero.Noop(node))
         push(impero.Accumulate(node))

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -92,9 +92,6 @@ def compile_integral(integral_data, form_data, prefix, parameters, interface, *,
     :arg log: bool if the Kernel should be profiled with Log events
     :returns: a kernel constructed by the kernel interface
     """
-    if integral_data.domain.ufl_cell().cellname() == "hexahedron" and \
-       integral_data.integral_type == "interior_facet":
-        raise NotImplementedError("interior facet integration in hex meshes not currently supported")
     parameters = preprocess_parameters(parameters)
     if interface is None:
         interface = firedrake_interface_loopy.KernelBuilder

--- a/tsfc/kernel_args.py
+++ b/tsfc/kernel_args.py
@@ -52,3 +52,11 @@ class ExteriorFacetKernelArg(KernelArg):
 
 class InteriorFacetKernelArg(KernelArg):
     ...
+
+
+class ExteriorFacetOrientationKernelArg(KernelArg):
+    ...
+
+
+class InteriorFacetOrientationKernelArg(KernelArg):
+    ...

--- a/tsfc/kernel_interface/__init__.py
+++ b/tsfc/kernel_interface/__init__.py
@@ -34,6 +34,10 @@ class KernelInterface(metaclass=ABCMeta):
         """Facet or vertex number as a GEM index."""
 
     @abstractmethod
+    def entity_orientation(self, restriction):
+        """Entity orientation as a GEM index."""
+
+    @abstractmethod
     def create_element(self, element, **kwargs):
         """Create a FInAT element (suitable for tabulating with) given
         a UFL element."""

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -91,6 +91,11 @@ class KernelBuilderBase(KernelInterface):
         # Assume self._entity_number dict is set up at this point.
         return self._entity_number[restriction]
 
+    def entity_orientation(self, restriction):
+        """Facet orientation as a GEM index."""
+        # Assume self._entity_orientation dict is set up at this point.
+        return self._entity_orientation[restriction]
+
     def apply_glue(self, prepare=None, finalise=None):
         """Append glue code for operations that are not handled in the
         GEM abstraction.


### PR DESCRIPTION
Generalise:

- `VariableIndex` to allow for `VariableIndex(some_general_expr)`,
- `FlexiblyIndexed` to allow for `FlexiblyIndexed((offset_expr, ((index_or_variableindex, stride_expr), )), ...)`.

The above changes then let us permute quadrature points based on the provided orientation data, giving us a way to enable interior facet integration on hex.

Potential TODO:

- enable full index arithmetic (and retire `FlexiblyIndexed`).
- attach `dtype` to each `Terminal` and let operators inherit `dtype` from children.

Depend on :
https://github.com/FInAT/FInAT/pull/138
https://github.com/firedrakeproject/fiat/pull/83