### PR TITLE
Refine dtype logic for Power node

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -415,12 +415,18 @@ class Power(Scalar):
 
         # Constant folding
         if isinstance(base, Zero):
-            dtype = numpy.result_type(base.dtype, exponent.dtype)
+            if isinstance(exponent, Constant):
+                dtype = numpy.result_type(base.dtype, exponent.dtype)
+            else:
+                dtype = base.dtype
             if isinstance(exponent, Zero):
                 raise ValueError("cannot solve 0^0")
             return Zero(dtype=dtype)
         elif isinstance(exponent, Zero):
-            dtype = numpy.result_type(base.dtype, exponent.dtype)
+            if isinstance(base, Constant):
+                dtype = numpy.result_type(base.dtype, exponent.dtype)
+            else:
+                dtype = exponent.dtype
             return Literal(1, dtype=dtype)
         elif isinstance(base, Constant) and isinstance(exponent, Constant):
             dtype = numpy.result_type(base.dtype, exponent.dtype)


### PR DESCRIPTION
We know how to optimise `0 ** x` and `x ** 0` to a `Zero` or `Constant(1)` node, but we can't assume that `x` is an instance of `Constant` with a defined dtype.